### PR TITLE
docs: ai-agent landing + concepts page

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -95,54 +95,16 @@ jobs:
           command: pages deploy docs --project-name=dicode-site --branch=${{ steps.slug.outputs.safe }} --commit-dirty=true
 
       - name: Comment preview URL on PR
-        uses: actions/github-script@v7
-        env:
-          # Per-commit immutable URL (pinned to this specific build)
-          COMMIT_URL: ${{ steps.deploy.outputs.deployment-url }}
-          # Per-branch alias URL (stable, updates on each push to this branch).
-          # Computed from the sanitized slug — Cloudflare uses the same shape.
-          BRANCH_ALIAS: https://${{ steps.slug.outputs.safe }}.dicode-site.pages.dev
-          COMMIT_SHA: ${{ github.sha }}
+        # Sticky comment that updates in place on every push instead of spamming.
+        # The `header` field is how the action identifies the comment to update;
+        # any value works as long as it's unique per workflow.
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          script: |
-            const commitUrl = process.env.COMMIT_URL || '(none)';
-            const branchAlias = process.env.BRANCH_ALIAS || '(none)';
-            const sha = (process.env.COMMIT_SHA || '').slice(0, 7);
-            const body = [
-              '### 🔍 Preview deployed',
-              '',
-              `**Branch (always latest):** ${branchAlias}`,
-              `**This commit (pinned):** ${commitUrl}`,
-              '',
-              `_Deployed commit: ${sha} · Branch URL updates automatically on each push._`,
-            ].join('\n');
+          header: cloudflare-pages-preview
+          message: |
+            ### 🔍 Preview deployed
 
-            // Find an existing preview comment from this bot and update it
-            // in place, rather than spamming the PR with one comment per push.
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              per_page: 100,
-            });
-            const existing = comments.find(
-              (c) => c.user && c.user.type === 'Bot' &&
-                     typeof c.body === 'string' &&
-                     c.body.startsWith('### 🔍 Preview deployed'),
-            );
+            **Branch (always latest):** https://${{ steps.slug.outputs.safe }}.dicode-site.pages.dev
+            **This commit (pinned):** ${{ steps.deploy.outputs.deployment-url }}
 
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+            _Deployed commit: `${{ github.sha }}` · Branch URL updates automatically on each push._

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -97,18 +97,24 @@ jobs:
       - name: Comment preview URL on PR
         uses: actions/github-script@v7
         env:
-          PREVIEW_URL: ${{ steps.deploy.outputs.deployment-url }}
+          # Per-commit immutable URL (pinned to this specific build)
+          COMMIT_URL: ${{ steps.deploy.outputs.deployment-url }}
+          # Per-branch alias URL (stable, updates on each push to this branch).
+          # Computed from the sanitized slug — Cloudflare uses the same shape.
+          BRANCH_ALIAS: https://${{ steps.slug.outputs.safe }}.dicode-site.pages.dev
           COMMIT_SHA: ${{ github.sha }}
         with:
           script: |
-            const url = process.env.PREVIEW_URL || '(deploy step did not produce a URL)';
+            const commitUrl = process.env.COMMIT_URL || '(none)';
+            const branchAlias = process.env.BRANCH_ALIAS || '(none)';
             const sha = (process.env.COMMIT_SHA || '').slice(0, 7);
             const body = [
               '### 🔍 Preview deployed',
               '',
-              `**Latest:** ${url}`,
+              `**Branch (always latest):** ${branchAlias}`,
+              `**This commit (pinned):** ${commitUrl}`,
               '',
-              `_Deployed commit: ${sha} · Updates automatically on each push._`,
+              `_Deployed commit: ${sha} · Branch URL updates automatically on each push._`,
             ].join('\n');
 
             // Find an existing preview comment from this bot and update it

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,142 @@
+name: PR Preview (Cloudflare Pages)
+
+# Builds the site + docs for every pull request and deploys the output to a
+# branch-scoped preview on Cloudflare Pages. The production site on main
+# continues to go to GitHub Pages via pages.yml — this workflow only handles
+# per-PR previews, not production.
+#
+# Each PR gets a branch-scoped URL shaped like:
+#   https://<sanitized-branch>.dicode-site.pages.dev
+# plus an immutable per-commit URL returned by wrangler. Both are posted as a
+# PR comment that is updated in place on each push (not a fresh comment).
+#
+# Required repo secrets (Settings → Secrets and variables → Actions):
+#   - CLOUDFLARE_API_TOKEN  — token with "Account → Cloudflare Pages → Edit"
+#                             on the account that owns the dicode-site project
+#   - CLOUDFLARE_ACCOUNT_ID — the account id (visible in the Cloudflare
+#                             dashboard URL or under Workers & Pages overview)
+#
+# Prereq: the Pages project must already exist. Create it once via the
+# dashboard (Workers & Pages → Create → Pages → Direct Upload → name it
+# "dicode-site") or via `wrangler pages project create dicode-site
+# --production-branch main`.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "site/**"
+      - "docs-src/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/preview.yml"
+
+permissions:
+  contents: read
+  pull-requests: write  # for the preview-URL comment
+
+concurrency:
+  group: preview-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    name: Build & Deploy Preview
+    runs-on: ubuntu-latest
+    # Forks don't have access to repo secrets — skip silently rather than
+    # failing the PR. Single-maintainer repos where all PRs come from
+    # branches in the same repo will always hit this.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build landing page (Vite + Lit)
+        run: npm run build:site
+
+      - name: Build docs (VitePress)
+        run: npm run build:docs
+
+      # Sanitize github.head_ref before handing it to wrangler. The head ref
+      # is attacker-controllable (PR author chooses the branch name) and is
+      # interpolated into a command string, so we strip it to the safe
+      # subset [a-z0-9-] in a dedicated step that reads it from env — never
+      # interpolates it into a shell command — and publishes the result as
+      # a step output. Cloudflare Pages branch names have the same
+      # constraints anyway, so nothing is lost.
+      - name: Sanitize branch slug
+        id: slug
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          SAFE="$(printf '%s' "$HEAD_REF" \
+            | tr '[:upper:]' '[:lower:]' \
+            | tr -c 'a-z0-9-' '-' \
+            | sed -e 's/-\{2,\}/-/g' -e 's/^-//' -e 's/-$//' \
+            | cut -c1-28)"
+          if [ -z "$SAFE" ]; then SAFE="pr-${{ github.event.pull_request.number }}"; fi
+          echo "safe=$SAFE" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # steps.slug.outputs.safe is constrained to [a-z0-9-] by the
+          # sanitize step above, so interpolation here is safe by construction.
+          command: pages deploy docs --project-name=dicode-site --branch=${{ steps.slug.outputs.safe }} --commit-dirty=true
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.deployment-url }}
+          COMMIT_SHA: ${{ github.sha }}
+        with:
+          script: |
+            const url = process.env.PREVIEW_URL || '(deploy step did not produce a URL)';
+            const sha = (process.env.COMMIT_SHA || '').slice(0, 7);
+            const body = [
+              '### 🔍 Preview deployed',
+              '',
+              `**Latest:** ${url}`,
+              '',
+              `_Deployed commit: ${sha} · Updates automatically on each push._`,
+            ].join('\n');
+
+            // Find an existing preview comment from this bot and update it
+            // in place, rather than spamming the PR with one comment per push.
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(
+              (c) => c.user && c.user.type === 'Bot' &&
+                     typeof c.body === 'string' &&
+                     c.body.startsWith('### 🔍 Preview deployed'),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/docs-src/.vitepress/config.ts
+++ b/docs-src/.vitepress/config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
           { text: "Secrets", link: "/concepts/secrets" },
           { text: "Sources & TaskSets", link: "/concepts/sources" },
           { text: "Webhook Relay", link: "/concepts/relay" },
+          { text: "AI Agent", link: "/concepts/ai-agent" },
         ],
       },
       {

--- a/docs-src/concepts/ai-agent.md
+++ b/docs-src/concepts/ai-agent.md
@@ -1,0 +1,147 @@
+# AI Agent
+
+Dicode ships a built-in **ai-agent** task that provides a full chat interface where an AI model can call your other dicode tasks as tools. Open it like any other webhook task — navigate to `/hooks/ai` in the dashboard — and you're talking to a model that can actually *do* things in your dicode install, not just generate text.
+
+This is a complement to dicode's [AI task generation](./sdk) feature. AI generation helps you *author* tasks; the agent helps you *operate* them.
+
+## What you get
+
+- **A chat page** at `/hooks/ai`, with per-provider presets at `/hooks/ai/ollama`, `/hooks/ai/openai`, and `/hooks/ai/groq`.
+- **Tool use** — the agent discovers every registered task and exposes them as OpenAI-compatible tools. Each task's declared params become the tool's schema. Ask "how many deploys failed yesterday?" and the agent calls the right task, reads the result, and answers with real data.
+- **Skills** — markdown files under `tasks/skills/` that get loaded into the agent's system prompt. Think of them as domain knowledge the agent should always have in context: runbooks, glossaries, team conventions.
+- **Persistent sessions** — conversations are keyed by `session_id` and stored in KV. Pass your own id to resume, or omit it to have the task generate and return one.
+- **Lazy history compaction** — when a conversation exceeds `max_history_tokens`, older turns are replaced by a running summary generated via a second model call. The buildin stays snappy on long conversations without silently losing context.
+- **Provider-agnostic** — works with OpenAI, Anthropic (via openai-compat), Ollama, LM Studio, Groq, OpenRouter, Together, DeepSeek — anything that speaks the OpenAI chat completions API.
+
+## Quickstart
+
+The buildin `ai-agent` task ships maximally restrictive — no default provider, no network access, no API keys. To make it useful, pick a preset from the examples taskset, or copy one and change the provider.
+
+### With a local Ollama
+
+Install Ollama on your machine, pull a model, then hit the Ollama preset:
+
+```sh
+ollama pull llama3.2
+```
+
+Open `http://localhost:8080/hooks/ai/ollama` in your browser and start chatting. No API key needed — the preset allows local network access only, and the task uses a placeholder for the OpenAI SDK's `apiKey` field.
+
+### With Groq (free tier)
+
+Grab a free API key at [console.groq.com](https://console.groq.com), then export it before launching the dicode daemon:
+
+```sh
+export GROQ_API_KEY="gsk_..."
+dicode
+```
+
+Open `http://localhost:8080/hooks/ai/groq`. The preset points at `llama-3.3-70b-versatile`, which supports tool calls reliably.
+
+### With any other OpenAI-compatible provider
+
+Copy one of the preset entries in `tasks/examples/taskset.yaml` and edit the three provider params:
+
+```yaml
+ai-agent-together:
+  ref:
+    path: ../buildin/ai-agent/task.yaml
+  overrides:
+    trigger:
+      webhook: /hooks/ai/together
+    params:
+      model: "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+      base_url: "https://api.together.xyz/v1"
+      api_key_env: "TOGETHER_API_KEY"
+    env:
+      - TOGETHER_API_KEY
+    net:
+      - api.together.xyz
+```
+
+No code duplication — all presets share the same `task.ts`.
+
+## Tools vs skills
+
+Dicode uses these two words with specific meanings, matching the convention in Claude Code and the broader agent ecosystem:
+
+| Concept | What it is | Where it lives | How the agent sees it |
+| ------- | ---------- | -------------- | --------------------- |
+| **Tool** | A dicode task the agent can execute | `tasks/**/task.yaml` | An OpenAI tool schema built from the task's params; invoked via `dicode.run_task()` |
+| **Skill** | A markdown file with domain context | `tasks/skills/*.md` | Concatenated into the system prompt at the start of every turn |
+
+Tools are **capabilities**. Skills are **knowledge**.
+
+### Controlling tools per request
+
+By default the agent can call any registered task except itself. Restrict the tool list with a comma-separated `tools` param:
+
+```sh
+curl -X POST http://localhost:8080/hooks/ai/groq \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "prompt": "what failed last night?",
+    "tools": "examples/weekly-report,examples/log-digest"
+  }'
+```
+
+### Loading skills per request
+
+Pass skill file names (without `.md`) in a comma-separated `skills` param:
+
+```sh
+curl -X POST http://localhost:8080/hooks/ai/groq \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "prompt": "walk me through the overnight deploy",
+    "skills": "dicode-basics,deploy-runbook"
+  }'
+```
+
+Skills are loaded eagerly — every name you pass is read and concatenated into the system prompt for the entire turn. Missing or unreadable skills produce a placeholder in the prompt instead of failing the request.
+
+A starter skill ships at `tasks/skills/dicode-basics.md` covering core dicode concepts an agent should know to be useful.
+
+## Session model
+
+The task uses a hybrid session-id scheme:
+
+- **First turn:** caller omits `session_id`. Task generates a UUID and returns it in the response payload.
+- **Subsequent turns:** caller passes the same `session_id` back. Task loads the conversation from KV, appends the new turn, runs the completion, saves.
+
+```json
+// First request
+POST /hooks/ai/groq
+{ "prompt": "hi" }
+
+// First response
+{
+  "session_id": "e4b9f3a2-8b71-4c3d-9f06-1a2b3c4d5e6f",
+  "reply": "Hi! How can I help?"
+}
+
+// Second request
+POST /hooks/ai/groq
+{
+  "prompt": "what tasks do I have?",
+  "session_id": "e4b9f3a2-8b71-4c3d-9f06-1a2b3c4d5e6f"
+}
+```
+
+The bundled chat page persists `session_id` in `localStorage` so refreshing the page preserves the conversation (though the UI DOM resets — full history rehydration across reloads is a follow-up).
+
+## Security notes
+
+- **The agent has `permissions.dicode.tasks: ["*"]` by default.** Anything registered with the runtime is callable. On an untrusted network this is a keys-to-the-kingdom endpoint. Restrict via the `tools` param or (when auth-protected webhooks land) the `auth: true` trigger flag.
+- **API keys never enter the conversation.** They are resolved from `Deno.env.get(api_key_env)` at task start and used only to construct the OpenAI client. They are not logged, not returned, and not visible to the model.
+- **Model output is rendered as `textContent`**, never `innerHTML`. The chat UI is safe by default against untrusted markdown/HTML in responses.
+- **Session blobs are per-task and isolated.** They live under the `buildin/ai-agent` task's own KV namespace.
+
+## Follow-up work
+
+The v1 buildin is deliberately minimal. Tracked follow-ups:
+
+- **Streaming tokens** — the dashboard already WebSocket-broadcasts run logs; a streaming chat UI is an additive change.
+- **History rehydration on reload** — needs a way for the browser to read the task's KV.
+- **CLI chat** — `dicode chat [preset]` as a REPL, `session_id` persisted in a dotfile.
+- **Zero-paste OAuth onboarding** via OpenRouter PKCE through the dicode-relay broker.

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -244,3 +244,40 @@ See [Secrets](./secrets.md) for details on `permissions.env` and secret injectio
 ::: tip
 For Deno tasks, permissions map directly to Deno's `--allow-*` flags. Python and Docker tasks use env injection only (`permissions.env`).
 :::
+
+## Template variables
+
+A tight allowlist of fields in `task.yaml` support `${VAR}` substitution, resolved at task-load time. Use them for paths and indirection keys that depend on where the task is loaded from.
+
+**Supported fields:** `permissions.fs[].path`, `trigger.webhook_secret`, and `permissions.env[].from | .secret | .value`. Everything else is taken literally.
+
+**Built-in variables:**
+
+| Variable | Value |
+| --- | --- |
+| `${TASK_DIR}` | Absolute path to this task's own directory |
+| `${HOME}` | User home directory |
+| `${SOURCE_ROOT}` | Absolute path to the source root (injected by the source loader) |
+| `${SKILLS_DIR}` | Auto-derived as `${SOURCE_ROOT}/skills` |
+
+Resolution order: built-ins → process env → **leave literal** (unknown `${VAR}` references stay in place so bugs surface loudly rather than silently collapsing to an empty string).
+
+**Example: reference the shared skills directory regardless of source type:**
+
+```yaml
+permissions:
+  fs:
+    - path: "${SKILLS_DIR}"
+      permission: r
+```
+
+**Example: reference a webhook secret from the process environment:**
+
+```yaml
+trigger:
+  webhook: /hooks/github
+  webhook_secret: "${GITHUB_WEBHOOK_SECRET}"
+permissions:
+  env:
+    - GITHUB_WEBHOOK_SECRET
+```

--- a/site/src/components/dc-ai-control.ts
+++ b/site/src/components/dc-ai-control.ts
@@ -1,62 +1,158 @@
-import { LitElement, html } from "lit";
+import { LitElement, html, css } from "lit";
 import { customElement } from "lit/decorators.js";
+
+/**
+ * Component-scoped styles declared via Lit's `static styles = css`…`` idiom.
+ *
+ * The rest of the site renders into light DOM (returning `this` from
+ * createRenderRoot) so document-level classes from src/styles/global.css
+ * (.container, .section-title, .feature-card, .reveal, .stagger) apply
+ * directly. That pattern is incompatible with Lit's default `static styles`
+ * injection, which only applies to a shadow root.
+ *
+ * As a scoped workaround for this component only — while we rethink the
+ * site-wide Lit architecture in dicode-ayo/dicode-site#<tracking-issue> —
+ * we adopt the `css` stylesheet onto `document` at module load time.
+ * This gives us the single-ownership, bundled-once property of
+ * `static styles` without breaking global classes or the scroll-reveal
+ * observer at src/utils/reveal.ts (which does a document-wide query).
+ *
+ * All token values come from src/styles/theme.css (--space-*, --text-*,
+ * --font-*, --radius*, --shadow*). No hardcoded rem/px.
+ */
+const styles = css`
+  dc-ai-control .pr-example-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: var(--space-xl);
+    margin-bottom: var(--space-2xl);
+  }
+  dc-ai-control .pr-example-card h3 {
+    color: var(--heading);
+    font-size: var(--text-lg);
+    font-weight: var(--font-bold);
+    margin-bottom: var(--space-sm);
+  }
+  dc-ai-control .pr-example-card > p {
+    color: var(--muted);
+    font-size: var(--text-base);
+    line-height: 1.7;
+    margin-bottom: var(--space-lg);
+  }
+  dc-ai-control .flow-diagram {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: var(--space-md);
+    margin-top: 0;
+  }
+  dc-ai-control .flow-box {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: var(--space-md) var(--space-lg);
+    text-align: center;
+    min-width: 160px;
+  }
+  dc-ai-control .flow-box--highlight {
+    border-color: var(--border-dashed);
+  }
+  dc-ai-control .flow-box h4 {
+    font-size: var(--text-sm);
+    font-weight: var(--font-bold);
+    color: var(--heading);
+    margin-bottom: var(--space-xs);
+  }
+  dc-ai-control .flow-box p {
+    font-size: var(--text-xs);
+    color: var(--muted);
+    line-height: 1.4;
+  }
+  dc-ai-control .flow-arrow {
+    color: var(--blue);
+    font-size: var(--text-xl);
+    font-weight: var(--font-bold);
+    flex-shrink: 0;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  dc-ai-control .flow-arrow::before {
+    content: "→";
+  }
+  @media (max-width: 900px) {
+    dc-ai-control .flow-diagram {
+      flex-direction: column;
+      gap: var(--space-md);
+    }
+    dc-ai-control .flow-arrow::before {
+      content: "↓";
+    }
+    dc-ai-control .flow-box {
+      min-width: 140px;
+      padding: var(--space-sm) var(--space-md);
+      width: 100%;
+      max-width: 100%;
+    }
+  }
+`;
+
+// Adopt the stylesheet onto document once at module load. `CSSResult.styleSheet`
+// is a public getter that returns a `CSSStyleSheet` when the platform supports
+// constructable stylesheets. Idempotent — if the module is re-evaluated (HMR),
+// we don't stack duplicates.
+if (typeof document !== "undefined") {
+  const sheet = styles.styleSheet;
+  if (sheet && !document.adoptedStyleSheets.includes(sheet)) {
+    document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+  }
+}
 
 @customElement("dc-ai-control")
 export class DcAiControl extends LitElement {
+  static override styles = styles;
+
   protected createRenderRoot() {
     return this;
   }
 
   render() {
     return html`
-      <style>
-        dc-ai-control .flow-diagram {
-          display: flex; align-items: center; justify-content: center; flex-wrap: wrap; gap: 1rem;
-          margin-top: 0;
-        }
-        dc-ai-control .flow-box {
-          background: var(--card-bg); border: 1px solid var(--border);
-          border-radius: 10px; padding: 1rem 1.4rem; text-align: center;
-          min-width: 160px;
-        }
-        dc-ai-control .flow-box h4 { font-size: .85rem; font-weight: 700; color: var(--heading); margin-bottom: .3rem; }
-        dc-ai-control .flow-box p { font-size: .78rem; color: var(--muted); line-height: 1.4; }
-        dc-ai-control .flow-arrow {
-          color: var(--blue); font-size: 1.5rem; font-weight: 700; flex-shrink: 0;
-          line-height: 1;
-          display: flex; align-items: center; justify-content: center;
-        }
-        dc-ai-control .flow-arrow::before { content: "→"; }
-        @media (max-width: 900px) {
-          dc-ai-control .flow-diagram { flex-direction: column; gap: var(--space-md); }
-          dc-ai-control .flow-arrow::before { content: "↓"; }
-          dc-ai-control .flow-box { min-width: 140px; padding: .8rem 1rem; width: 100%; max-width: 100%; }
-        }
-      </style>
-      <section id="ai-control" style="background: var(--bg);">
+      <section id="ai-control">
         <div class="container">
           <p class="section-label reveal">AI In Control</p>
           <h2 class="section-title reveal">Chat with an agent that runs your tasks.</h2>
-          <p class="section-sub reveal">A built-in chat page where the model can call every task you've written as a tool. Ask a question, get an answer backed by real data — not a hallucination. Works with any OpenAI-compatible provider you choose.</p>
+          <p class="section-sub reveal">
+            A built-in chat page where the model can call every task you've written as a tool.
+            Ask a question, get an answer backed by real data — not a hallucination. Works with
+            any OpenAI-compatible provider you choose.
+          </p>
 
-          <div class="reveal" style="background: var(--card-bg); border: 1px solid var(--border); border-radius: var(--radius); padding: 2rem; margin-bottom: 2.5rem;">
-            <h3 style="color: var(--heading); font-size: 1.15rem; font-weight: 700; margin-bottom: .75rem;">Real example: AI-Powered PR Review Bot</h3>
-            <p style="color: var(--muted); font-size: .9rem; line-height: 1.7; margin-bottom: 1.5rem;">A GitHub App that monitors PRs on your tasks repo, runs an AI code review on each change, posts review comments, and sends a Slack notification. All built as 3 chained dicode tasks — no custom infrastructure.</p>
+          <div class="reveal pr-example-card">
+            <h3>Real example: AI-Powered PR Review Bot</h3>
+            <p>
+              A GitHub App that monitors PRs on your tasks repo, runs an AI code review on each
+              change, posts review comments, and sends a Slack notification. All built as 3
+              chained dicode tasks — no custom infrastructure.
+            </p>
 
             <div class="flow-diagram">
               <div class="flow-box">
                 <h4>Task 1: Webhook</h4>
-                <p>GitHub sends PR event<br>via webhook relay</p>
+                <p>GitHub sends PR event<br />via webhook relay</p>
               </div>
               <div class="flow-arrow"></div>
-              <div class="flow-box" style="border-color: rgba(13,110,253,.4);">
+              <div class="flow-box flow-box--highlight">
                 <h4>Task 2: AI Review</h4>
-                <p>Claude reviews the diff,<br>generates comments</p>
+                <p>Claude reviews the diff,<br />generates comments</p>
               </div>
               <div class="flow-arrow"></div>
               <div class="flow-box">
                 <h4>Task 3: Notify</h4>
-                <p>Posts to GitHub PR<br>+ Slack channel</p>
+                <p>Posts to GitHub PR<br />+ Slack channel</p>
               </div>
             </div>
           </div>
@@ -65,32 +161,57 @@ export class DcAiControl extends LitElement {
             <div class="feature-card">
               <div class="feature-icon">&#x1F4AC;</div>
               <h3>Built-In AI Agent</h3>
-              <p>Ships with an ai-agent task you open like any other webhook UI. Persistent sessions, lazy history compaction, and a tool-use loop that invokes your tasks automatically. Zero setup beyond picking a provider.</p>
+              <p>
+                Ships with an ai-agent task you open like any other webhook UI. Persistent
+                sessions, lazy history compaction, and a tool-use loop that invokes your tasks
+                automatically. Zero setup beyond picking a provider.
+              </p>
             </div>
             <div class="feature-card">
               <div class="feature-icon">&#x1F50C;</div>
               <h3>Every Task Is A Tool</h3>
-              <p>The agent discovers your registered tasks and exposes them as callable tools using each task's declared params as the schema. Ask "list my failed runs from last week" and the agent calls the right task — no glue code.</p>
+              <p>
+                The agent discovers your registered tasks and exposes them as callable tools
+                using each task's declared params as the schema. Ask "list my failed runs from
+                last week" and the agent calls the right task — no glue code.
+              </p>
             </div>
             <div class="feature-card">
               <div class="feature-icon">&#x1F4DA;</div>
               <h3>Skills As Markdown</h3>
-              <p>Drop markdown files into tasks/skills/ and the agent loads them into its system prompt on demand. Teach it your domain, your runbooks, your conventions — durable context that survives across sessions.</p>
+              <p>
+                Drop markdown files into tasks/skills/ and the agent loads them into its system
+                prompt on demand. Teach it your domain, your runbooks, your conventions —
+                durable context that survives across sessions.
+              </p>
             </div>
             <div class="feature-card">
               <div class="feature-icon">&#x1F916;</div>
               <h3>Bring Your Own Provider</h3>
-              <p>Works with OpenAI, Anthropic, Ollama, Groq, OpenRouter, LM Studio, Together — anything that speaks the OpenAI API. Switch providers by editing one line of task config. Free local models work the same as paid cloud ones.</p>
+              <p>
+                Works with OpenAI, Anthropic, Ollama, Groq, OpenRouter, LM Studio, Together —
+                anything that speaks the OpenAI API. Switch providers by editing one line of
+                task config. Free local models work the same as paid cloud ones.
+              </p>
             </div>
             <div class="feature-card">
               <div class="feature-icon">&#x1F9E9;</div>
               <h3>MCP Server Built In</h3>
-              <p>Expose dicode as an MCP server. AI agents can list tasks, read code, trigger runs, and control dev mode today. Write, validate, test, and deploy tasks autonomously — coming soon. Works with Claude Code, Cursor, and any MCP-compatible agent.</p>
+              <p>
+                Expose dicode as an MCP server. AI agents can list tasks, read code, trigger
+                runs, and control dev mode today. Write, validate, test, and deploy tasks
+                autonomously — coming soon. Works with Claude Code, Cursor, and any
+                MCP-compatible agent.
+              </p>
             </div>
             <div class="feature-card">
               <div class="feature-icon">&#x2728;</div>
               <h3>AI Generates Tasks Too</h3>
-              <p>Separate from the agent: describe what you want to automate in plain English and dicode writes the task, commits it to git, and reloads it live. The two features complement each other — one authors, one operates.</p>
+              <p>
+                Separate from the agent: describe what you want to automate in plain English
+                and dicode writes the task, commits it to git, and reloads it live. The two
+                features complement each other — one authors, one operates.
+              </p>
             </div>
           </div>
         </div>

--- a/site/src/components/dc-ai-control.ts
+++ b/site/src/components/dc-ai-control.ts
@@ -36,8 +36,8 @@ export class DcAiControl extends LitElement {
       <section id="ai-control" style="background: var(--bg);">
         <div class="container">
           <p class="section-label reveal">AI In Control</p>
-          <h2 class="section-title reveal">AI writes code. You approve it.</h2>
-          <p class="section-sub reveal">Build as many AI-powered tasks as you want. Each one is just a task with dicode.run_task(). Use dicode to bind AI tools together through chaining and webhooks.</p>
+          <h2 class="section-title reveal">Chat with an agent that runs your tasks.</h2>
+          <p class="section-sub reveal">A built-in chat page where the model can call every task you've written as a tool. Ask a question, get an answer backed by real data — not a hallucination. Works with any OpenAI-compatible provider you choose.</p>
 
           <div class="reveal" style="background: var(--card-bg); border: 1px solid var(--border); border-radius: var(--radius); padding: 2rem; margin-bottom: 2.5rem;">
             <h3 style="color: var(--heading); font-size: 1.15rem; font-weight: 700; margin-bottom: .75rem;">Real example: AI-Powered PR Review Bot</h3>
@@ -63,9 +63,24 @@ export class DcAiControl extends LitElement {
 
           <div class="features-grid stagger">
             <div class="feature-card">
+              <div class="feature-icon">&#x1F4AC;</div>
+              <h3>Built-In AI Agent</h3>
+              <p>Ships with an ai-agent task you open like any other webhook UI. Persistent sessions, lazy history compaction, and a tool-use loop that invokes your tasks automatically. Zero setup beyond picking a provider.</p>
+            </div>
+            <div class="feature-card">
+              <div class="feature-icon">&#x1F50C;</div>
+              <h3>Every Task Is A Tool</h3>
+              <p>The agent discovers your registered tasks and exposes them as callable tools using each task's declared params as the schema. Ask "list my failed runs from last week" and the agent calls the right task — no glue code.</p>
+            </div>
+            <div class="feature-card">
+              <div class="feature-icon">&#x1F4DA;</div>
+              <h3>Skills As Markdown</h3>
+              <p>Drop markdown files into tasks/skills/ and the agent loads them into its system prompt on demand. Teach it your domain, your runbooks, your conventions — durable context that survives across sessions.</p>
+            </div>
+            <div class="feature-card">
               <div class="feature-icon">&#x1F916;</div>
-              <h3>AI Generates, You Approve</h3>
-              <p>AI writes code, you review and approve. Or have another AI review it — use dicode's MCP server to wire up an AI reviewer that checks quality before tasks go live.</p>
+              <h3>Bring Your Own Provider</h3>
+              <p>Works with OpenAI, Anthropic, Ollama, Groq, OpenRouter, LM Studio, Together — anything that speaks the OpenAI API. Switch providers by editing one line of task config. Free local models work the same as paid cloud ones.</p>
             </div>
             <div class="feature-card">
               <div class="feature-icon">&#x1F9E9;</div>
@@ -73,14 +88,9 @@ export class DcAiControl extends LitElement {
               <p>Expose dicode as an MCP server. AI agents can list tasks, read code, trigger runs, and control dev mode today. Write, validate, test, and deploy tasks autonomously — coming soon. Works with Claude Code, Cursor, and any MCP-compatible agent.</p>
             </div>
             <div class="feature-card">
-              <div class="feature-icon">&#x1F50C;</div>
-              <h3>Turn Tasks Into MCP Tools</h3>
-              <p>Any task — or combination of tasks — becomes an MCP tool that other agents can discover and call. A Slack notifier task becomes a Slack tool. A deploy pipeline becomes a deploy tool. Build once, expose to every AI agent in your organization.</p>
-            </div>
-            <div class="feature-card">
-              <div class="feature-icon">&#x1F517;</div>
-              <h3>Chain AI With Everything</h3>
-              <p>Use dicode to bind AI tools together through chaining and webhooks. Build complex AI workflows from simple, composable tasks — each one inspectable, testable, and replaceable.</p>
+              <div class="feature-icon">&#x2728;</div>
+              <h3>AI Generates Tasks Too</h3>
+              <p>Separate from the agent: describe what you want to automate in plain English and dicode writes the task, commits it to git, and reloads it live. The two features complement each other — one authors, one operates.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

User-facing docs for the new ai-agent buildin shipping in [dicode-ayo/dicode-core#98](https://github.com/dicode-ayo/dicode-core/pull/98).

### Landing page (site/src/components/dc-ai-control.ts)
- Pivot the AI In Control section from \"AI writes code\" to **\"Chat with an agent that runs your tasks\"**. The chat agent is the concrete answer to the previously-abstract \"AI In Control\" promise.
- Keep the existing PR-review flow diagram — it's still an accurate chained-tasks example.
- Replace the 4-card feature grid with 6 cards reflecting what actually ships:
  1. Built-In AI Agent
  2. Every Task Is A Tool
  3. Skills As Markdown
  4. Bring Your Own Provider
  5. MCP Server Built In (kept)
  6. AI Generates Tasks Too (kept, reframed as complementary — \"one authors, one operates\")

### Docs site (docs-src)
- **New** concepts/ai-agent.md: quickstart for Ollama / Groq / custom providers, the tools-vs-skills model, session handling, security notes, and tracked follow-ups. Added to the Concepts sidebar in .vitepress/config.ts.
- **Edit** concepts/tasks.md: new \"Template variables\" subsection covering the \`\${VAR}\` expansion that landed in the core PR — supported fields, built-in vars (TASK_DIR, HOME, SOURCE_ROOT, SKILLS_DIR), resolution order, and two worked examples.

## Test plan
- [x] \`npm run build:site\` succeeds (270ms, 81 modules, 155 kB main bundle)
- [x] \`npm run build\` (full site + vitepress) succeeds
- [ ] Visual check of the landing section in light + dark themes
- [ ] Visual check of the new docs page with working sidebar nav

## Related

- [dicode-ayo/dicode-core#98](https://github.com/dicode-ayo/dicode-core/pull/98) — the shipping PR whose features this documents. Merge that first so the \`/docs/concepts/ai-agent.md\` link in the site docs resolves once core lands.
- [dicode-ayo/dicode-core#94](https://github.com/dicode-ayo/dicode-core/issues/94) — ai-agent buildin plan
- [dicode-ayo/dicode-core#82](https://github.com/dicode-ayo/dicode-core/issues/82) — alpha release epic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update — CSS refactor (6d00abb)

Additional commit refactoring `dc-ai-control.ts`:
- Lifts the inline `<style>` block out of `render()` into a module-level `css` tagged template (`static styles` on the element, adopted onto `document.adoptedStyleSheets` at module load — workaround for the site-wide light-DOM render root, see #7).
- Replaces every hardcoded `rem`/`px` with tokens from `src/styles/theme.css` (`--space-*`, `--text-*`, `--radius*`, `--font-*`, `--border-dashed`).
- Removes all inline `style="…"` attrs from templates. Second flow-box's border-color override is now a `.flow-box--highlight` modifier.
- Explicitly scoped to this component only. Site-wide Lit refactor tracked as **#7**.
