### PR TITLE
ci: add Cloudflare Pages production deployment

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,0 +1,74 @@
+name: Deploy Production (Cloudflare Pages)
+
+# Builds the site + docs on every push to main and deploys to the production
+# branch of the dicode-site Cloudflare Pages project. Lives at
+# https://dicode-site.pages.dev (and, after the dashboard custom-domain step,
+# at https://dicode.app).
+#
+# This workflow runs in parallel with .github/workflows/pages.yml during the
+# migration window. Both produce the same output; only the destination differs.
+# Once dicode.app DNS is repointed to Cloudflare and confirmed serving, the
+# legacy pages.yml + the CNAME files in site/public/ and docs/ should be
+# removed in a follow-up PR.
+#
+# This workflow takes no input from PR metadata or commit messages — every
+# interpolation is a secret or a hardcoded literal — so there is no command
+# injection surface.
+#
+# Required repo secrets (already configured for preview.yml):
+#   - CLOUDFLARE_API_TOKEN
+#   - CLOUDFLARE_ACCOUNT_ID
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - "docs-src/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/production.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Production deploys are mutually exclusive — never run two at once. New
+# pushes wait for the in-flight deploy rather than cancelling it.
+concurrency:
+  group: cloudflare-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build & Deploy to Cloudflare
+    runs-on: ubuntu-latest
+    environment:
+      name: cloudflare-production
+      url: https://dicode-site.pages.dev
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build landing page (Vite + Lit)
+        run: npm run build:site
+
+      - name: Build docs (VitePress)
+        run: npm run build:docs
+
+      - name: Deploy to Cloudflare Pages (production)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # --branch=main makes this the production deployment for the
+          # dicode-site project. Without --branch it would deploy as a
+          # preview at a per-commit URL only.
+          command: pages deploy docs --project-name=dicode-site --branch=main --commit-dirty=true


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/production.yml\` that deploys the site + docs to the production branch of the dicode-site Cloudflare Pages project on every push to main. Sets up the parallel deployment that lets us migrate \`dicode.app\` from GitHub Pages to Cloudflare Pages with **zero downtime**.

This is **PR 1 of 2** for the migration:

1. **PR #7 (this one)** — additive only. Runs alongside the existing GitHub Pages workflow. Both deployments stay in sync. \`dicode.app\` continues serving from GitHub Pages until DNS is repointed.
2. **PR 8 (after DNS swap is verified)** — subtractive. Removes \`pages.yml\` and the two CNAME files (\`site/public/CNAME\`, \`docs/CNAME\`).

## What this workflow does

- **Trigger:** push to \`main\` (paths-filtered to site, docs, package files, the workflow itself)
- **Build:** same two steps as the existing pages.yml (\`npm run build:site\` then \`npm run build:docs\`)
- **Deploy:** \`wrangler pages deploy docs --project-name=dicode-site --branch=main\` — the \`--branch=main\` flag is what makes Cloudflare treat this as the production deployment, not a preview
- **Concurrency:** \`cloudflare-production\` group with \`cancel-in-progress: false\` — production deploys serialize and never get cancelled mid-flight
- **No PR comment, no branch sanitization, no fork guard** — none of those apply to push-to-main

Re-uses the existing \`CLOUDFLARE_API_TOKEN\` / \`CLOUDFLARE_ACCOUNT_ID\` secrets already configured for \`preview.yml\`. **No new secrets to add.**

## Verification plan

After merge:

1. Workflow runs on the merge commit
2. Open https://dicode-site.pages.dev — should be the current site (still served by GitHub Pages at dicode.app for now)
3. Visually compare against https://dicode.app — they should be identical
4. If anything looks off, fix forward; \`dicode.app\` is unaffected because GitHub Pages is still serving it

## Manual steps after merge (the DNS swap)

DNS is on Cloudflare, so this is fast:

1. **Cloudflare dashboard → Workers & Pages → dicode-site → Custom domains → Set up a custom domain**
2. Enter \`dicode.app\` → click through. Cloudflare detects DNS is on the same account and offers one-click activation
3. (Optionally also add \`www.dicode.app\` if you want both)
4. Wait ~10 seconds for the cert + routing to propagate
5. Open https://dicode.app in a browser → check the response headers for \`server: cloudflare\` and \`cf-ray: ...\` to confirm it's now served from Cloudflare
6. Disable GitHub Pages: repo Settings → Pages → Source: **None** (this stops the legacy workflow from publishing, but doesn't delete its existing artifact — that's safe to leave)
7. Open PR 2 to remove \`pages.yml\` and the CNAME files

## Test plan

- [ ] Workflow appears in the Actions tab after merge
- [ ] Deploy step succeeds (uses the same token + account ID as preview.yml, which is known working)
- [ ] https://dicode-site.pages.dev serves the site
- [ ] Visual parity with https://dicode.app
- [ ] **Manual** dashboard step: custom domain attached
- [ ] **Manual** verification: \`curl -I https://dicode.app\` shows \`server: cloudflare\`

## Risk

**Zero risk to dicode.app.** This PR doesn't touch DNS, doesn't touch \`pages.yml\`, doesn't touch the CNAME files, and doesn't disable GitHub Pages. \`dicode.app\` keeps serving from GitHub Pages for the entire window between this merging and PR 2 merging. The only thing this PR changes is what's deployed to Cloudflare Pages.

If the workflow fails for any reason post-merge, the impact is "Cloudflare doesn't get updated" — \`dicode.app\` itself continues to work fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)