### PR TITLE
docs: document env.if_missing prereq directive

### DIFF
--- a/docs-src/concepts/ai-agent.md
+++ b/docs-src/concepts/ai-agent.md
@@ -179,4 +179,7 @@ The v1 buildin is deliberately minimal. Tracked follow-ups:
 - **Streaming tokens** — the dashboard already WebSocket-broadcasts run logs; a streaming chat UI is an additive change.
 - **History rehydration on reload** — needs a way for the browser to read the task's KV.
 - **CLI chat** — `dicode chat [preset]` as a REPL, `session_id` persisted in a dotfile.
-- **Zero-paste OAuth onboarding** via OpenRouter PKCE through the dicode-relay broker.
+
+### Zero-paste onboarding with `if_missing`
+
+The `ai-agent-openrouter` preset chains a local PKCE OAuth task via the `if_missing` directive on its API-key env entry: the first time a user hits the chat with no `OPENROUTER_API_KEY` stored, the engine runs [`auth/openrouter-oauth`](../getting-started/configuration) before the real task, which surfaces an authorize URL. One browser click stores the key; every subsequent message skips the prereq and runs normally. No relay, no broker, no app registration — OpenRouter's flow accepts an arbitrary `callback_url` as a request parameter. See the [Secrets concepts page](./secrets#running-a-prereq-task-when-a-secret-is-missing) for the general mechanism.

--- a/docs-src/concepts/secrets.md
+++ b/docs-src/concepts/secrets.md
@@ -41,6 +41,27 @@ permissions:
       value: info
 ```
 
+### Running a prereq task when a secret is missing
+
+Secret-backed entries accept an `if_missing:` directive that names a task to run *before* the main task dispatches when the secret isn't present in the store. This is the hook that turns a first-time OAuth flow into zero-paste onboarding: the user triggers the real task, the engine notices the key is absent, fires the OAuth task in chain mode, and only runs the real task once the key is stored.
+
+```yaml
+permissions:
+  env:
+    - name: OPENROUTER_API_KEY
+      secret: OPENROUTER_API_KEY
+      if_missing:
+        task: auth/openrouter-oauth
+        # params: { ... }    # optional, forwarded to the prereq task
+```
+
+Behavior:
+
+- Secret present → `if_missing` is a no-op; task runs immediately.
+- Secret missing → engine synchronously fires the named task in chain mode. If it succeeds and the secret is now resolvable, the main task runs. If it fails — for example an OAuth flow throwing *"Open this URL to authorize: …"* — that error becomes the main task's failure, giving the UI a clickable setup link to show the user.
+
+Only `secret:`-backed entries honor `if_missing:`. On `from:`, `value:`, or bare entries the directive is silently ignored — there's no secret to check for in the first place.
+
 ---
 
 ## Provider chain

--- a/docs-src/concepts/sharing.md
+++ b/docs-src/concepts/sharing.md
@@ -109,13 +109,13 @@ To share a task with the community:
 2. Open a PR to add your repo URL to the community registry TaskSet
 3. That's it — no packaging, no publishing step
 
-## Multi-machine deployment
+## Running on multiple machines
 
-Point multiple dicode daemons at the same git repo:
+Point multiple dicode daemons at the same git repo. Each daemon is independent — it reconciles the repo on its own, with no cross-daemon coordination, no shared cluster state, and no orchestration layer:
 
 - **Home server** — runs monitoring, backups, media processing (24/7 tasks)
 - **Laptop** — runs dev tasks, webhook receivers, interactive UIs
 - **VPS** — runs public webhook endpoints, scheduled jobs
 - **Raspberry Pi** — runs IoT data collection, sensor polling
 
-All from one git repo. Git push — all machines update within 30 seconds. Use separate TaskSet entry points or env-based overrides to control which tasks run where.
+Each daemon picks up a `git push` within its poll interval (30s default, or instantly via git webhook). Use separate TaskSet entry points or env-based overrides to control which tasks run where.

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -93,6 +93,10 @@ permissions:
       secret: db_password
     - name: LOG_LEVEL            # literal value
       value: info
+    - name: OAUTH_KEY            # inject from store, run a prereq task if absent
+      secret: OAUTH_KEY
+      if_missing:
+        task: auth/some-oauth    # see Secrets page for details
   fs:                            # Deno only: filesystem access
     - path: /tmp
       permission: rw

--- a/docs-src/index.md
+++ b/docs-src/index.md
@@ -73,10 +73,10 @@ features:
     link: /concepts/sharing
     linkText: Task sharing docs
   - icon: "\U0001F4E1"
-    title: Multi-Machine Fleet
-    details: "Same git repo, multiple dicode daemons on different machines. Home server runs monitoring, laptop runs dev tasks, VPS handles public webhooks, Raspberry Pi collects sensor data. Git push — all update within 30 seconds. No orchestration layer, no service mesh. Just git + multiple binaries."
+    title: Runs on Many Machines
+    details: "One git repo, independent daemons on whatever machines you like. Home server runs monitoring, laptop runs dev tasks, VPS handles public webhooks, Raspberry Pi collects sensor data. Each daemon reconciles the repo on its own — no orchestration layer, no service mesh, no shared cluster state. Git push reaches every machine within its poll interval (30s default, instant via webhook)."
     link: /concepts/sharing
-    linkText: Multi-machine deployment
+    linkText: Running on multiple machines
   - icon: "\U0001F50D"
     title: Rich Web Dashboard
     details: "Full-featured UI: create tasks from prompts, manage TaskSets and sources, edit code with Monaco editor (with inline AI chat), view live logs via WebSocket, manage secrets, configure settings. Desktop tray app on macOS, Linux, Windows with failure notifications. Or go CLI-only — your choice."


### PR DESCRIPTION
## Summary

Documents the new [\`env[].if_missing:\`](https://github.com/dicode-ayo/dicode-core/pull/117) directive landing in dicode-core, which lets a task declare a prereq task to run when a secret is absent — powering zero-paste OAuth onboarding.

- **Secrets page** — new "Running a prereq task when a secret is missing" section with the mechanism, the \`OPENROUTER_API_KEY\` example, and the behavior breakdown (present → no-op, missing → run prereq, prereq fails → error surfaces for UI to render a setup link).
- **Tasks page** — added an \`if_missing\` line to the env-block overview example so readers meeting the permissions shape for the first time see all meaningful forms.
- **AI-agent page** — replaced the "zero-paste onboarding via the relay broker" follow-up bullet with a shipped subsection pointing at \`auth/openrouter-oauth\` + \`if_missing\`. The relay was never needed for OpenRouter because its flow accepts an arbitrary \`callback_url\` as a request param, no app registration required.

## Test plan

- [ ] Site build renders all three pages without broken links (the cross-reference from ai-agent.md → secrets.md uses a relative anchor).
- [ ] Visual check: the new secrets section reads as a natural continuation after "All env entry forms".