### PR TITLE
docs: auth passphrase + /login return-to-origin flow

### DIFF
--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -69,7 +69,7 @@ trigger:
   cron: "0 9 * * *"              # 5-field cron expression
   webhook: /hooks/my-task        # HTTP path
   webhook_secret: "${SECRET}"    # HMAC-SHA256 secret (env var interpolation)
-  auth: true                     # require dicode session auth for webhook
+  auth: true                     # require dicode session — see /concepts/triggers#session-authentication
   manual: true                   # only triggered explicitly
   daemon: true                   # long-running process
   restart: always                # daemon only: always | on-failure | never

--- a/docs-src/concepts/triggers.md
+++ b/docs-src/concepts/triggers.md
@@ -68,7 +68,32 @@ trigger:
   auth: true
 ```
 
-When `auth: true` is set, both GET (UI) and POST (run) requests require a valid dicode session. Unauthenticated requests are redirected to the login page.
+When `auth: true` is set, both GET (UI) and POST (run) requests require a valid dicode session. Any webhook task can opt in — the built-in dashboard at `/hooks/webui` and the `ai-agent` task both ship with `auth: true` by default.
+
+#### Login flow
+
+Unauthenticated browser GETs to a protected webhook path are redirected with `303 See Other` to `/login?next=<original-path>`:
+
+```
+GET /hooks/dashboard
+  ↓ 303
+/login?next=%2Fhooks%2Fdashboard
+  ↓ user enters passphrase, form POSTs to /api/auth/login
+  ↓ 303 (session cookie set)
+/hooks/dashboard          ← original target
+```
+
+The login page resolves the task's `name` and `description` from the registry when `next=/hooks/<id>` is a known webhook, so users see *which* task they're signing in to access (e.g. "Sign in to access AI Agent") rather than a generic prompt.
+
+**API clients** (requests without `Accept: text/html`) receive `401 JSON` instead of a redirect, preserving machine-readable behaviour for curl, fetch, and SDK callers.
+
+#### Safety
+
+The `next` parameter is validated as a same-origin path. Values that don't start with `/`, contain protocol-relative prefixes (`//`, `/\`), include backslashes or CR/LF, or parse to anything with a scheme/host/opaque component are rejected. Unsafe values fall back to `/hooks/webui` (form POST) or are dropped from the response (JSON POST). Open-redirect abuse attempts like `?next=//evil.com`, `?next=https://evil.com`, or `?next=javascript:…` cannot escape the same origin.
+
+#### Setting up the passphrase
+
+See [Auth passphrase](/getting-started/configuration#auth-passphrase) in the configuration guide for how the passphrase is generated on first boot, where it's stored, and how to rotate or recover it.
 
 ### Webhook task UIs
 

--- a/docs-src/getting-started/configuration.md
+++ b/docs-src/getting-started/configuration.md
@@ -163,7 +163,7 @@ Individual tasks can override notification settings with the `notify` field in `
 server:
   port: 8080                # HTTP server port (default: 8080)
   auth: false               # enable passphrase auth wall (default: false)
-  secret: ""                # passphrase for auth (when auth: true)
+  secret: ""                # passphrase override; leave empty to auto-generate on first boot
   allowed_origins: []       # CORS allowlist; empty = same-origin only
   trust_proxy: false        # trust X-Forwarded-For headers
   mcp: true                 # expose MCP endpoint at /mcp (default: true)
@@ -173,6 +173,39 @@ server:
 ```
 
 The server hosts the web UI, the REST API, and the MCP endpoint. When `mcp` is enabled, AI tools like Claude Code and Cursor can discover and call your tasks via the Model Context Protocol.
+
+### Auth passphrase
+
+When `server.auth: true`, the dashboard, REST API, and any webhook task declaring `trigger.auth: true` require a valid dicode session.
+
+**Where the passphrase comes from**, in priority order:
+
+1. `server.secret` — YAML override; highest priority
+2. `kv["auth.passphrase"]` — stored in SQLite; managed via the dashboard or API
+3. _(none)_ — on first boot with `server.auth: true` and no passphrase set, dicode auto-generates a cryptographically random 43-character passphrase and prints it to stdout **once**:
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║  dicode — auth passphrase generated                          ║
+║                                                              ║
+║  <43-char passphrase>                                        ║
+║                                                              ║
+║  Save this somewhere safe. You can change it any time at     ║
+║  /security in the web UI (requires a valid session).         ║
+╚══════════════════════════════════════════════════════════════╝
+```
+
+Save it somewhere safe — the banner is not shown again. The passphrase is immediately persisted in SQLite; subsequent restarts read it from the database.
+
+**Rotating the passphrase.** Once you have a valid session, visit `/security` in the dashboard or `POST /api/auth/passphrase` with `{"current": "…", "passphrase": "…"}`. New passphrases must be at least 16 characters.
+
+**Recovering a lost passphrase.** Delete the stored value and restart — dicode will auto-generate and print a new one:
+
+```sh
+sqlite3 <datadir>/dicode.db "DELETE FROM kv WHERE key='auth.passphrase';"
+```
+
+**YAML override behaviour.** When `server.secret` is set, the API refuses passphrase rotation requests with `409 Conflict` to prevent split-brain state between YAML and database. Remove the YAML field to manage the passphrase via the dashboard.
 
 ## AI
 


### PR DESCRIPTION
## Summary

Brings user-facing docs in line with the auth flow shipping in dicode-core [#131](https://github.com/dicode-ayo/dicode-core/pull/131) (`fix(webui): redirect unauth webhook access to /login with return-to-origin`). Before this PR the site had one-line mentions of \`auth: true\` and \`server.secret\` with no narrative for new users.

## Changes

- **[getting-started/configuration.md](docs-src/getting-started/configuration.md)** — new **Auth passphrase** subsection covering:
  - Passphrase source priority (\`server.secret\` YAML → \`kv[\"auth.passphrase\"]\` DB → auto-generate)
  - First-boot banner (exact format shown, "printed once")
  - Rotation via \`/security\` UI or \`POST /api/auth/passphrase\`
  - Recovery by deleting the kv row
  - YAML override 409 Conflict behaviour
- **[concepts/triggers.md](docs-src/concepts/triggers.md)** — flesh out **Session authentication**:
  - Full \`/login?next=<path>\` redirect flow with a visual trace
  - Task name/description shown on the login page (from registry)
  - API clients still get \`401 JSON\` (preserves curl / fetch / SDK behaviour)
  - Safety section: same-origin validator + rejected abuse vectors
  - Cross-link to configuration.md for passphrase setup
- **[concepts/tasks.md](docs-src/concepts/tasks.md)** — update the one-line \`auth: true\` comment in the task spec example to point at the new triggers.md section.

## Test plan

- [x] Renders cleanly locally (VitePress headings resolve, anchors valid)
- [x] Scrolls cold-read: new user can set \`server.auth: true\`, first-boot the daemon, read the banner, log in via \`/login\`, reach a protected webhook
- [ ] Cross-reference against dicode-core [#131](https://github.com/dicode-ayo/dicode-core/pull/131) once merged — the docs match the shipped behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)