### PR TITLE
docs: sync with direct-AI removal in dicode-core#134

### DIFF
--- a/docs-src/concepts/ai-agent.md
+++ b/docs-src/concepts/ai-agent.md
@@ -41,7 +41,7 @@ The dial between human control and AI autonomy is yours to set.
 
 ## What you get
 
-- **A chat page** at `/hooks/ai`, with per-provider presets at `/hooks/ai/ollama`, `/hooks/ai/openai`, and `/hooks/ai/groq`.
+- **A chat page** at `/hooks/ai`, with per-provider presets at `/hooks/ai/ollama`, `/hooks/ai/openai`, and `/hooks/ai/groq`. The task-detail page in the dashboard also embeds a dedicated agent at `/hooks/ai/dicodai` (the `buildin/dicodai` preset) preloaded with the `dicode-task-dev` skill — that's the one powering the "AI" chat button when you're editing a task.
 - **Tool use** — the agent discovers every registered task and exposes them as OpenAI-compatible tools. Each task's declared params become the tool's schema. Ask "how many deploys failed yesterday?" and the agent calls the right task, reads the result, and answers with real data.
 - **Skills** — markdown files under `tasks/skills/` that get loaded into the agent's system prompt. Think of them as domain knowledge the agent should always have in context: runbooks, glossaries, team conventions.
 - **Persistent sessions** — conversations are keyed by `session_id` and stored in KV. Pass your own id to resume, or omit it to have the task generate and return one.

--- a/docs-src/concepts/sdk.md
+++ b/docs-src/concepts/sdk.md
@@ -205,9 +205,6 @@ export default async function main({ dicode }: DicodeSdk) {
   // Get recent runs for a task (requires permissions.dicode.get_runs)
   const runs = await dicode.get_runs("other-task", { limit: 5 });
 
-  // Read config section (requires permissions.dicode.get_config)
-  const aiConfig = await dicode.get_config("ai");
-
   // Manage secrets (requires permissions.dicode.secrets_write)
   await dicode.secrets_set("MY_API_KEY", "sk-abc123");
   await dicode.secrets_delete("OLD_KEY");
@@ -223,9 +220,6 @@ tasks = dicode.list_tasks()
 
 # Get recent runs for a task (requires permissions.dicode.get_runs)
 runs = dicode.get_runs("other-task", limit=5)
-
-# Read config section (requires permissions.dicode.get_config)
-ai_config = dicode.get_config("ai")
 ```
 
 :::
@@ -237,7 +231,6 @@ async def main():
     result = await dicode.run_task_async("other-task", {"key": "value"})
     tasks = await dicode.list_tasks_async()
     runs = await dicode.get_runs_async("other-task", limit=5)
-    config = await dicode.get_config_async("ai")
 ```
 
 ### API
@@ -247,7 +240,6 @@ async def main():
 | Run task | `await dicode.run_task(id, params?)` | `dicode.run_task(id, params=None)` | `await dicode.run_task_async(id, params=None)` |
 | List tasks | `await dicode.list_tasks()` | `dicode.list_tasks()` | `await dicode.list_tasks_async()` |
 | Get runs | `await dicode.get_runs(id, opts?)` | `dicode.get_runs(id, limit=10)` | `await dicode.get_runs_async(id, limit=10)` |
-| Get config | `await dicode.get_config(section)` | `dicode.get_config(section)` | `await dicode.get_config_async(section)` |
 | Set secret | `await dicode.secrets_set(key, value)` | -- | -- |
 | Delete secret | `await dicode.secrets_delete(key)` | -- | -- |
 
@@ -263,7 +255,6 @@ permissions:
     tasks: ["target-task-id"]    # or ["*"] for all
     list_tasks: true
     get_runs: true
-    get_config: true
     secrets_write: true
     mcp: ["mcp-daemon-id"]
 ```

--- a/docs-src/concepts/sources.md
+++ b/docs-src/concepts/sources.md
@@ -122,7 +122,7 @@ The override system can patch these fields without modifying the original task.y
 - `timeout`
 - `runtime`
 - `notify` (on_success, on_failure)
-- `dicode` permissions (tasks, mcp, list_tasks, get_runs, get_config, secrets_write)
+- `dicode` permissions (tasks, mcp, list_tasks, get_runs, secrets_write)
 
 ### Nested entry overrides
 

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -107,7 +107,6 @@ permissions:
     mcp: ["my-mcp-daemon"]       # mcp.list_tools() / mcp.call() targets
     list_tasks: true             # dicode.list_tasks()
     get_runs: true               # dicode.get_runs()
-    get_config: true             # dicode.get_config()
     secrets_write: true          # dicode.secrets_set() / secrets_delete()
 
 docker:                          # docker/podman runtime only

--- a/docs-src/concepts/triggers.md
+++ b/docs-src/concepts/triggers.md
@@ -68,7 +68,7 @@ trigger:
   auth: true
 ```
 
-When `auth: true` is set, both GET (UI) and POST (run) requests require a valid dicode session. Any webhook task can opt in — the built-in dashboard at `/hooks/webui` and the `ai-agent` task both ship with `auth: true` by default.
+When `auth: true` is set, both GET (UI) and POST (run) requests require a valid dicode session. Any webhook task can opt in — for example, the built-in dashboard at `/hooks/webui` and the `dicodai` preset at `/hooks/ai/dicodai` both ship with `auth: true` because they're only ever called from within an authenticated dicode session.
 
 #### Login flow
 


### PR DESCRIPTION
## Summary
- Removes `dicode.get_config("ai")` / `get_config_async` / `permissions.dicode.get_config` from SDK docs (method deleted in dicode-core#134).
- Corrects `triggers.md`: the `auth: true` example was misattributed to `ai-agent`; it now points at the new `buildin/dicodai` preset (the one that actually ships with auth on).
- Notes the task-detail AI chat panel is powered by `buildin/dicodai` preloaded with the `dicode-task-dev` skill.

## Upstream
Companion to https://github.com/dicode-ayo/dicode-core/pull/134 — merge after that one lands so the docs don't reference the removed SDK method before it disappears from release builds.

## Test plan
- [ ] `pnpm docs:build` (or local vitepress dev) renders updated pages without broken links
- [ ] Spot-check /concepts/sdk, /concepts/triggers, /concepts/ai-agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)