### PR TITLE
ci(preview): skip Cloudflare Pages deploy on dependabot PRs

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -43,10 +43,16 @@ jobs:
   deploy-preview:
     name: Build & Deploy Preview
     runs-on: ubuntu-latest
-    # Forks don't have access to repo secrets — skip silently rather than
-    # failing the PR. Single-maintainer repos where all PRs come from
-    # branches in the same repo will always hit this.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Skip when the run won't have access to the Cloudflare secrets:
+    #   1. PRs from forks — repo secrets aren't exposed to fork runs.
+    #   2. Dependabot PRs — although they live in this repo (passing the
+    #      fork guard), GitHub isolates them from Actions secrets under a
+    #      separate "Dependabot secrets" namespace, so wrangler would fail
+    #      with an empty CLOUDFLARE_API_TOKEN. Previews of dep bumps have
+    #      essentially no review value anyway. If we ever want them, mirror
+    #      the CF secrets into Settings → Secrets → Dependabot and drop the
+    #      actor check.
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
Five open dependabot PRs (#12 #13 #14 #15 #27) all fail the same required check (`Build & Deploy Preview`) at the wrangler step:

> In a non-interactive environment, it's necessary to set a `CLOUDFLARE_API_TOKEN` environment variable for wrangler to work.

The token is empty because GitHub isolates dependabot runs from Actions secrets — those live under a separate **Settings → Secrets → Dependabot** namespace, so the workflow's `${{ secrets.CLOUDFLARE_API_TOKEN }}` resolves to `""`. The fork guard at the top of the job doesn't help: dependabot PRs come from branches in this repo and pass it.

This adds `&& github.actor != 'dependabot[bot]'` to the existing `if:` so the deploy job is skipped (green) on dep bumps. Test/lint coverage is unaffected.

## Why this and not the secrets-mirror approach
A Cloudflare preview of `bump typescript from 6.0.2 to 6.0.3` has essentially no review value, and mirroring secrets across two namespaces is a forever-tax (rotation has to happen in two places, drift is invisible). The escape hatch is documented inline so the decision is reversible without spelunking history.

## Test plan
- [ ] Once merged: re-run CI on #12 (or any dependabot PR) and confirm the `deploy-preview` job is `skipped`, not `failed`. The required check should report green.
- [ ] Open a regular PR (non-dependabot) touching `site/**` to confirm previews still deploy normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)