### PR TITLE
docs(connect): clarify managed-relay vs self-hosted OAuth

### DIFF
--- a/site/src/components/dc-connect.ts
+++ b/site/src/components/dc-connect.ts
@@ -150,9 +150,11 @@ export class DcConnect extends LitElement {
           <p class="section-label reveal">One-Click OAuth</p>
           <h2 class="section-title reveal">Click. Authenticate. Done.</h2>
           <p class="section-sub reveal">
-            No client IDs. No app registration. No ngrok for callbacks. Click "Connect" in the UI,
-            authenticate with the provider, and the token appears in your daemon &mdash; encrypted
-            end-to-end with ECIES. 14 providers, zero setup.
+            On the managed relay: click "Connect", authenticate, and the token reaches your daemon
+            &mdash; ECIES end-to-end. 14 providers, zero app registration.
+          </p>
+          <p class="section-sub reveal">
+            Self-hosting? Bring your own OAuth app credentials. Same crypto path, same UX.
           </p>
           <div class="provider-grid stagger">
             ${AVAILABLE.map(
@@ -189,8 +191,7 @@ export class DcConnect extends LitElement {
             </div>
           </div>
           <p class="connect-footer reveal">
-            No app registration needed. Missing a provider? Write your own OAuth flow —
-            dicode gives you the building blocks.
+            Missing a provider? Write your own OAuth flow &mdash; dicode gives you the building blocks.
             <a href="/docs/concepts/relay" style="color:var(--sky); text-decoration:none; font-weight:var(--font-semibold);">Read more &rarr;</a>
           </p>
         </div>


### PR DESCRIPTION
## Summary

Closes #33
Part of dicode-ayo/dicode-core#207

The current `dc-connect` hero copy reads:

> No client IDs. No app registration. No ngrok for callbacks. Click "Connect" in the UI, authenticate with the provider, and the token appears in your daemon — encrypted end-to-end with ECIES. 14 providers, zero setup.

This overstates the self-hosted experience. The relay broker holds shared `client_id`/`client_secret` only on the managed `dicode.app` tier — self-hosted users still register their own OAuth apps. `docs-src/concepts/relay.md` (lines 219–224) already concedes this with a clear "Self-hosted vs Pro" table; the landing page should align.

## Change

Replace the single sub-paragraph with two short beats so both audiences see themselves, and drop the matching "No app registration needed" claim from the footer:

```
On the managed relay: click "Connect", authenticate, and the token reaches your daemon
— ECIES end-to-end. 14 providers, zero app registration.

Self-hosting? Bring your own OAuth app credentials. Same crypto path, same UX.
```

```
Missing a provider? Write your own OAuth flow — dicode gives you the building blocks.
```

No layout, component, or CSS changes — both new paragraphs reuse the existing `.section-sub .reveal` class, so light/dark theming and reveal animation behave exactly as before.

## Verification

- `npx vite build site` succeeds (258 ms, 82 modules transformed).
- `vite dev` serves the updated component without HMR errors; `curl http://localhost:5173/src/components/dc-connect.ts` shows the new copy.
- TypeScript: no new errors introduced (pre-existing errors in `dc-runtimes.ts` and `main.ts` are untouched).
- Cross-checked against `docs-src/concepts/relay.md` § Self-hosted vs Pro — copy is now consistent with that table.

## Test plan

- [ ] Visual: load `/#connect` in dark mode at 1280px — two stacked sub-paragraphs render under the section title with the existing typography.
- [ ] Visual: light mode — same rendering, theme tokens unchanged.
- [ ] Visual: 375px mobile — copy wraps cleanly, provider grid layout unchanged.
- [ ] Reveal animation still fires on scroll into view.
- [ ] Footer "Read more →" link still points to `/docs/concepts/relay`.

> Note: visual capture from this run was blocked (Playwright MCP browser instance was stuck and headless Chrome execution was sandbox-denied). Reviewer please eyeball the section in the deploy preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)