### PR TITLE
docs(getting-started): add Docker quick-start subsection

### DIFF
--- a/docs-src/getting-started/index.md
+++ b/docs-src/getting-started/index.md
@@ -40,10 +40,14 @@ The published image runs as a non-root user and exposes the dashboard on port 80
 
 ```sh
 docker run -d --name dicode \
-  -p 8080:8080 \
+  -p 127.0.0.1:8080:8080 \
   -v dicode-data:/data \
   dicodeayo/dicode-core:latest
 ```
+
+The dashboard binds to localhost only — drop the `127.0.0.1:` prefix
+if you want it reachable from your LAN, but be aware the dashboard
+authenticates with a single shared passphrase.
 
 ### docker-compose
 
@@ -53,12 +57,12 @@ services:
     image: dicodeayo/dicode-core:latest
     restart: unless-stopped
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     volumes:
       - dicode-data:/data
-    environment:
-      # Inject any DICODE_* env vars (e.g. AI provider keys) here.
-      # See the secrets reference in the dashboard for required names.
+    # Keep secrets out of the compose file and out of version control.
+    # Put DICODE_* vars (AI provider keys, etc.) in a sibling .env file.
+    env_file: .env
 
 volumes:
   dicode-data:

--- a/docs-src/getting-started/index.md
+++ b/docs-src/getting-started/index.md
@@ -1,6 +1,6 @@
 # Installation & Quickstart
 
-dicode is a single Go binary that runs as a background daemon (`dicoded`) with a thin CLI (`dicode`) that auto-starts the daemon on first use. No containers, no infrastructure, no accounts required.
+dicode is a single Go binary that runs as a background daemon (`dicoded`) with a thin CLI (`dicode`) that auto-starts the daemon on first use. No infrastructure, no accounts required. A multi-arch Docker image is also published if you'd rather run it as a container.
 
 ## Install
 
@@ -33,6 +33,51 @@ Verify the installation:
 ```sh
 dicode version
 ```
+
+## Docker
+
+The published image runs as a non-root user and exposes the dashboard on port 8080. SQLite state lives at `/data` inside the container; mount a volume there to persist runs and task registrations across restarts.
+
+```sh
+docker run -d --name dicode \
+  -p 8080:8080 \
+  -v dicode-data:/data \
+  dicodeayo/dicode-core:latest
+```
+
+### docker-compose
+
+```yaml
+services:
+  dicode:
+    image: dicodeayo/dicode-core:latest
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - dicode-data:/data
+    environment:
+      # Inject any DICODE_* env vars (e.g. AI provider keys) here.
+      # See the secrets reference in the dashboard for required names.
+
+volumes:
+  dicode-data:
+```
+
+### Image registries
+
+| Registry | Image |
+| --- | --- |
+| Docker Hub (primary) | `dicodeayo/dicode-core` |
+| GHCR (mirror) | `ghcr.io/dicode-ayo/dicode-core` |
+
+### Tags
+
+- `:latest` -- most recent release
+- `:X.Y.Z` -- exact release (recommended for production)
+- `:X.Y` and `:X` -- track minor / major lines
+
+Multi-arch (`linux/amd64` + `linux/arm64`) for every published tag.
 
 ## Start the daemon
 


### PR DESCRIPTION
## Summary

- Adds a `## Docker` section to `docs-src/getting-started/index.md` directly after the existing tarball install code-group, mirroring the multi-arch image that lands in dicode-core [PR #227](https://github.com/dicode-ayo/dicode-core/pull/227).
- Covers a `docker run` one-liner, a `docker-compose` snippet, the Docker Hub primary / GHCR mirror registries, and the `:latest` / `:X.Y.Z` / `:X.Y` / `:X` tag scheme (multi-arch `linux/amd64` + `linux/arm64`).
- Softens the lead paragraph — "No containers, no infrastructure, no accounts required" no longer holds once we ship a published image, so it now reads "No infrastructure, no accounts required" with a one-liner pointing at the new section.

Closes #39.

## Test plan

- [x] `npm run build` (full Vite site + VitePress docs) completes without warnings or errors.
- [x] Built HTML at `docs/docs/getting-started/index.html` contains the new `Docker`, `docker-compose`, `Image registries`, and `Tags` headings, plus the `dicodeayo/dicode-core:latest` image references and the `linux/amd64` + `linux/arm64` arch lines.
- [x] No other sections regressed — Install / Start the daemon / Local-only mode / Add a git source / CLI commands / Next steps all still render.

## Notes

Blocked-on for visibility: dicode-core #227 must merge and publish at least one tag before this docs page is fully accurate end-to-end. The image references and tag scheme match what that PR publishes, so there is no further coupling.

Generated with Claude Code.