### PR TITLE
docs: auto-fix loop — concepts page + structured on_failure_chain + runs.get_input

### DIFF
--- a/docs-src/.vitepress/config.ts
+++ b/docs-src/.vitepress/config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
           { text: "Hot Reload & Dev Workflow", link: "/concepts/hot-reload" },
           { text: "Webhook Relay", link: "/concepts/relay" },
           { text: "AI Agent", link: "/concepts/ai-agent" },
+          { text: "Auto-fix Loop", link: "/concepts/auto-fix" },
           { text: "MCP Server", link: "/concepts/mcp-server" },
         ],
       },

--- a/docs-src/concepts/auto-fix.md
+++ b/docs-src/concepts/auto-fix.md
@@ -1,0 +1,139 @@
+# Auto-fix Loop
+
+When a task fails, dicode can fire an AI agent that diagnoses the failure, edits the failing task's source on a fix branch, validates the fix via tests + replay, then either pushes to the source's tracked branch (autonomous) or opens a pull request (review).
+
+This page documents the loop end-to-end. The individual SDK primitives are in [SDK Globals](./sdk.md).
+
+## How it works
+
+```
+┌────────────┐  fails   ┌────────────────────┐
+│ user task  │─────────▶│ trigger engine     │
+└────────────┘          │  on_failure_chain  │
+                        └─────────┬──────────┘
+                                  │ guards: cooldown, depth,
+                                  │   per-task & global concurrency,
+                                  │   per-source storm circuit breaker
+                                  ▼
+                        ┌────────────────────┐
+                        │ buildin/auto-fix   │  reads input + redacted_fields
+                        │  (ai-agent + skill)│  clones source on fix branch
+                        └─────────┬──────────┘  iterates: edit → test → replay
+                                  │
+                          ┌───────┴────────┐
+                  review  │                │  autonomous
+                          ▼                ▼
+                  ┌─────────────┐    ┌─────────────┐
+                  │ buildin/    │    │ git_commit_ │
+                  │   git-pr    │    │   push      │
+                  │ (gh CLI)    │    │ (tracked    │
+                  └─────────────┘    │   branch)   │
+                                     └─────────────┘
+```
+
+## Quick start
+
+Add `on_failure_chain: buildin/auto-fix` to any task that fails sometimes:
+
+```yaml
+# tasks/my-task/task.yaml
+runtime: deno
+trigger: { webhook: /hooks/process-payment }
+on_failure_chain:
+  task: buildin/auto-fix
+  params:
+    mode: review            # default — opens a PR for human approval
+    # mode: autonomous      # alternative — pushes directly to tracked branch
+```
+
+For autonomous mode you also need a fine-grained PAT in the secrets store under the key `GH_TOKEN_AUTOFIX`, scoped to **Contents: Read & write** + **Pull requests: Read & write** on the target repo.
+
+## What the agent does
+
+1. **Reads context.** Failed run's `taskID`, `runID`, `status`, `output`, plus the persisted input and `redacted_fields` (via `dicode.runs.get_input`).
+2. **Pins the input** so the daemon's retention sweeper doesn't delete it mid-loop.
+3. **Opens a fix branch** — clones the source under `${data}/dev-clones/<source>/<runID>/` checked out on `${branch_prefix}<runID>` (review) or the tracked branch (autonomous), via `dicode.sources.set_dev_mode`.
+4. **Iterates** (cap: `max_iterations`, default 5; per-iteration timeout `max_iteration_seconds`, default 300s):
+   - Read failing task's source files
+   - Edit (only inside the failing task's directory)
+   - Validate: re-typecheck, run `dicode.tasks.test(<failingTaskID>)`
+   - Replay: `dicode.runs.replay(<failedRunID>)` — succeeds because the agent's run was fired with `parent_run_id = <failedRunID>` (lineage check passes)
+   - If both green → exit loop
+5. **Commit + push** via `dicode.git.commit_push`.
+6. **Open the PR** (review only) via `dicode.run_task("git-pr", { ... })`.
+7. **Disable dev mode** — engine removes the local clone; the remote branch is retained.
+8. **Unpin input** (deferred cleanup also handles timeout / panic).
+
+The skill prompt [`dicode-auto-fix.md`](https://github.com/dicode-ayo/dicode-core/blob/main/tasks/skills/dicode-auto-fix.md) prescribes the exact sequence and the "do not write outside the failing task's directory" rule.
+
+## Engine guardrails
+
+The trigger engine enforces hard caps before every `on_failure_chain` fire — these protect against runaway loops, API budget burn, and concurrent-fix collisions.
+
+| Guard | Default | Override site |
+|---|---|---|
+| Cooldown per failing task | `10m` | `on_failure_chain.cooldown` |
+| Per-task concurrency cap | `1` | `on_failure_chain.max_concurrent` |
+| Global concurrency cap | `3` | `defaults.on_failure_chain.max_concurrent_global` (defaults-only) |
+| Chain depth | `2` hops | `on_failure_chain.max_depth` |
+| Storm circuit breaker | `> 10` fires within `1m` → suppress that source for `30m` | `defaults.on_failure_chain.storm.{rate, window, suppress}` (defaults-only) |
+| Replay → on_failure_chain | always suppressed | not configurable |
+| Branch prefix | `fix/` | `on_failure_chain.params.branch_prefix` |
+| `--force` push | always refused | not configurable |
+
+`max_concurrent_global` and `storm` are **operator policy** — only honored at the defaults level. Per-task blocks that set them get a config-load WARN and the fields are zeroed.
+
+State (cooldown timestamps, in-flight counters, storm windows) lives in memory on the daemon. A daemon restart resets it — by design for v1; persistence is a future enhancement.
+
+## Modes
+
+### Review mode (default)
+
+The agent commits + pushes the fix branch, then calls `buildin/git-pr` which shells out to `gh pr create`. A human reviews and merges. The remote branch stays even after the auto-fix run ends so reviewers see the diff.
+
+### Autonomous mode
+
+`mode: autonomous` skips the PR step and pushes directly to the source's tracked branch. The engine still validates the branch via `pkg/source/git.CommitPush` (no `--force`, branch must satisfy `branch_prefix` OR be the tracked branch with `allow_main: true`). Use only when the source repo has branch protection on the tracked branch (so a misfire still requires review).
+
+`mode` is **never inferred** by the engine for non-auto-fix chain targets — it's stamped automatically only when `on_failure_chain.task == buildin/auto-fix`.
+
+## Replay-fidelity caveat
+
+Persisted inputs are redacted at write time — fields named like `Authorization`, `password`, `secret`, signatures, etc. are stripped (see [run-input persistence in #233](https://github.com/dicode-ayo/dicode-core/pull/243)). The replayed run sees the redacted form, so:
+
+- A failing task that HMAC-validates the request body will not pass replay (the signature is gone).
+- A task that depends on `Authorization: Bearer <token>` will see an empty header.
+
+The `redacted_fields` array is surfaced in the agent's input so it can mention the gap in the PR body. Operators with sensitive auth flows should set `auto_fix.include_input: false` and let the agent reason from logs + output only.
+
+## Building your own auto-fix variant
+
+The `runs_get_input` permission was historically reserved for the buildin auto-fix preset, but is now YAML-grantable. Any task with `permissions.dicode.runs_get_input: true` can call `dicode.runs.get_input(runID)` — subject to a lineage check: caller's task must own the run, OR the caller's `parent_run_id` must match the requested run id.
+
+This means you can build:
+
+- A **custom replayer** with retry/backoff logic
+- An **audit task** that captures failure context to S3
+- A **fixer for a specific stack** that prefers smaller models or different prompts
+
+Just declare the permissions you need and wire them up. The buildin/auto-fix preset is a sensible default, not a magic blessing.
+
+```yaml
+# tasks/my-custom-fixer/task.yaml
+runtime: deno
+trigger: { manual: true }
+permissions:
+  dicode:
+    runs_get_input: true
+    runs_replay: true
+    sources_set_dev_mode: true
+    git_commit_push: true
+    tasks_test: true
+```
+
+## Related
+
+- [SDK Globals](./sdk.md) — the individual `dicode.runs.replay`, `dicode.tasks.test`, `dicode.sources.set_dev_mode`, `dicode.git.commit_push` methods
+- [Tasks](./tasks.md#field-reference) — `on_failure_chain` field reference
+- [Triggers](./triggers.md) — chain triggers in general
+- [Spec: on-failure auto-fix loop design](https://github.com/dicode-ayo/dicode-core/blob/main/docs/superpowers/specs/2026-04-28-on-failure-auto-fix-loop-design.md) — full design rationale

--- a/docs-src/concepts/sdk.md
+++ b/docs-src/concepts/sdk.md
@@ -290,6 +290,42 @@ permissions:
     runs_replay: true
 ```
 
+The replay is gated by an ownership check: the caller's task must own the run being replayed, OR the caller's `parent_run_id` must match the requested run (the auto-fix lineage). REST callers (operator-driven) bypass the check.
+
+---
+
+## dicode.runs.get_input
+
+Read another run's persisted input — used by replayer / fixer / auditor tasks that need to reason about what triggered a failure.
+
+::: code-group
+
+```ts [Deno]
+const persisted = await dicode.runs.get_input(failedRunID);
+// persisted: { source, params, body, headers, redacted_fields: ["Authorization", ...] }
+```
+
+```python [Python]
+persisted = dicode.runs.get_input(failed_run_id)
+# {"source": ..., "params": ..., "redacted_fields": [...]}
+```
+
+:::
+
+```yaml
+permissions:
+  dicode:
+    runs_get_input: true   # sensitive — grants cross-task input read
+```
+
+::: warning
+`runs_get_input` is **sensitive**. The redaction layer strips deny-listed fields (Authorization, secrets, signatures) at write time, but everything else — params, request bodies, headers — is readable. Grant only to tasks that legitimately need cross-task input access.
+:::
+
+The cap is gated by the same ownership check as `runs.replay`: caller owns the run OR caller's `parent_run_id` matches the requested run. This means the auto-fix loop works (chain-fired agent reads its parent's failed run) but a compromised task can't pivot to inspect arbitrary runs.
+
+The redaction layer is the bound on what's exposed — see [run-input persistence](https://github.com/dicode-ayo/dicode-core/pull/243) for the deny-list mechanics.
+
 ---
 
 ## dicode.tasks.test

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -131,7 +131,14 @@ docker:                          # docker/podman runtime only
 
 timeout: 30s                     # default 60s for script tasks; no default for docker/daemon
 mcp_port: 3000                   # daemon exposes MCP server on this port
-on_failure_chain: alert-task     # task to run on failure (overrides global default)
+on_failure_chain: alert-task     # short form — task to run on failure
+# or the structured form:
+# on_failure_chain:
+#   task: buildin/auto-fix
+#   params: { mode: review }
+#   cooldown: 10m
+#   max_concurrent: 1
+#   max_depth: 2
 
 notify:
   on_success: false
@@ -156,7 +163,7 @@ notify:
 | `docker` | object | conditional | Required when runtime is `docker` or `podman` |
 | `timeout` | duration | no | Max execution time (default `60s` for scripts) |
 | `mcp_port` | int | no | Port where a daemon task exposes an MCP server |
-| `on_failure_chain` | string | no | Task ID to trigger on failure |
+| `on_failure_chain` | string \| object | no | Task ID (short form) or structured block to trigger on failure. See [Auto-fix loop](./auto-fix.md). |
 | `notify` | object | no | Notification overrides |
 
 ### Trigger types


### PR DESCRIPTION
Documents dicode-core PR #247 (final block of the on-failure auto-fix epic, closes dicode-core#238 + dicode-core#246).

## What's added

**New \`/concepts/auto-fix\` page** — end-to-end coverage of the loop:
- How it works (architecture diagram + step-by-step)
- Quick start (\`on_failure_chain: buildin/auto-fix\`)
- What the agent does (read context → pin → branch → iterate → commit_push → PR → cleanup)
- Engine guardrails table (cooldown, concurrency, depth, storm circuit-breaker)
- Modes (review / autonomous)
- Replay-fidelity caveat (redaction → some auth flows can't be replayed)
- Building your own auto-fix variant — \`runs_get_input\` is now YAML-grantable

**\`/concepts/tasks\` updated:**
- Structured \`on_failure_chain\` example in the \`task.yaml\` reference
- Field-reference table updated to mention the structured form + link to the auto-fix page

**\`/concepts/sdk\` updated:**
- New \`dicode.runs.get_input\` section with the lineage-check warning + the \"sensitive\" callout
- Note on the lineage check for \`runs.replay\` (was implicit before)

**Sidebar:** \`Auto-fix Loop\` added under Concepts after AI Agent.

## Test plan
- [x] Page renders (vitepress markdown / code-group syntax matches surrounding entries)
- [ ] Visual review after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)