### PR TITLE
docs(oauth): mirror auth-X consolidation — broker is the source of truth for 13 providers

### DIFF
--- a/docs-src/concepts/relay.md
+++ b/docs-src/concepts/relay.md
@@ -127,9 +127,9 @@ The relay strips hop-by-hop headers (`Connection`, `Keep-Alive`, `Transfer-Encod
 
 The hosted relay at `relay.dicode.app` includes an **OAuth broker** that eliminates the need to register your own OAuth apps with providers. This is a key feature of the dicode.app Pro plan.
 
-The broker is the **single source of truth** for the providers it carries. As of `dicode-relay@0.1.5` that's 13 providers — `github`, `slack`, `google`, `spotify`, `linear`, `discord`, `gitlab`, `airtable`, `notion`, `confluence`, `salesforce`, `stripe`, `azure` — and dicode-core no longer ships per-provider entries (`auth/github-oauth`, `auth/google-oauth`, …) for any of them. With `relay.enabled: true` you get the full broker flow with zero per-provider configuration in your taskset; the dashboard's `buildin/auth-providers` task discovers the catalogue dynamically from `GET /providers`.
+The broker is the **single source of truth** for the providers it carries. As of `dicode-relay@0.1.5` that's 14 providers — `github`, `slack`, `google`, `spotify`, `linear`, `discord`, `gitlab`, `airtable`, `notion`, `confluence`, `salesforce`, `stripe`, `office365`, `azure` — and dicode-core no longer ships per-provider entries (`auth/github-oauth`, `auth/google-oauth`, …) for any of them. With `relay.enabled: true` you get the full broker flow with zero per-provider configuration in your taskset; the dashboard's `buildin/auth-providers` task discovers the catalogue dynamically from `GET /providers`.
 
-For providers the broker doesn't carry (e.g. Office 365, Looker) or for any provider you'd rather drive with your own OAuth app — see the [BYO flow](#byo-flow-providers-the-broker-doesn-t-carry) below.
+For providers the broker doesn't carry (e.g. Looker) or for any provider you'd rather drive with your own OAuth app — see the [BYO flow](#byo-flow-providers-the-broker-doesn-t-carry) below.
 
 ::: info Migration note (2026-05)
 Earlier dicode releases shipped per-provider entries `auth/github-oauth`, `auth/google-oauth`, `auth/slack-oauth`, etc. for every broker-backed provider. Those entries were removed once the broker became the source of truth — operators who relied on `/hooks/<provider>-oauth` callbacks for any of the 13 broker-backed providers should switch to the broker flow (no callback URL re-registration needed: the redirect URI lives on the broker, not your daemon). Operators who prefer to keep a self-hosted OAuth app for a specific provider can [instantiate `_oauth-app`](#byo-flow-providers-the-broker-doesn-t-carry) with their own credentials.
@@ -244,9 +244,9 @@ Self-hosted brokers can add providers by editing `relay.yaml` and restarting —
 
 ### BYO flow - providers the broker doesn't carry
 
-For providers the relay broker doesn't proxy (Office 365 / Microsoft Graph and Looker today), or for any provider you'd rather drive with your own OAuth app, dicode-core ships a generic OAuth task at `tasks/auth/_oauth-app/task.yaml`. You instantiate it from your own taskset with provider-specific overrides — the daemon talks to the provider directly, with credentials you store as secrets.
+For providers the relay broker doesn't proxy (Looker today), or for any provider you'd rather drive with your own OAuth app, dicode-core ships a generic OAuth task at `tasks/auth/_oauth-app/task.yaml`. You instantiate it from your own taskset with provider-specific overrides — the daemon talks to the provider directly, with credentials you store as secrets.
 
-The default `auth` taskset includes working examples (`office365-oauth`, `looker-oauth`, plus the standalone `openrouter-oauth`). To wire a new provider, copy one of those entries into your own taskset:
+The default `auth` taskset ships `looker-oauth` as a working example, plus the standalone `openrouter-oauth`. To wire a new provider, copy one of those entries into your own taskset:
 
 ```yaml
 # ~/dicode-tasks/taskset.yaml
@@ -342,7 +342,7 @@ Because the broker is the single source of truth, adding a new provider to `rela
 | | Self-hosted (free) | dicode.app Pro |
 |---|---|---|
 | Webhook relay | Yes (run your own server) | Yes (managed, unlimited) |
-| OAuth broker | No — instantiate `_oauth-app` per provider with your own apps | Yes — 13 providers, zero setup |
+| OAuth broker | No — instantiate `_oauth-app` per provider with your own apps | Yes — 14 providers, zero setup |
 | Custom domain | Your own domain | `*.dicode.app` |
 | Token encryption | N/A | ECIES (P-256 + AES-256-GCM) |
 

--- a/docs-src/concepts/relay.md
+++ b/docs-src/concepts/relay.md
@@ -127,6 +127,14 @@ The relay strips hop-by-hop headers (`Connection`, `Keep-Alive`, `Transfer-Encod
 
 The hosted relay at `relay.dicode.app` includes an **OAuth broker** that eliminates the need to register your own OAuth apps with providers. This is a key feature of the dicode.app Pro plan.
 
+The broker is the **single source of truth** for the providers it carries. As of `dicode-relay@0.1.5` that's 13 providers — `github`, `slack`, `google`, `spotify`, `linear`, `discord`, `gitlab`, `airtable`, `notion`, `confluence`, `salesforce`, `stripe`, `azure` — and dicode-core no longer ships per-provider entries (`auth/github-oauth`, `auth/google-oauth`, …) for any of them. With `relay.enabled: true` you get the full broker flow with zero per-provider configuration in your taskset; the dashboard's `buildin/auth-providers` task discovers the catalogue dynamically from `GET /providers`.
+
+For providers the broker doesn't carry (e.g. Office 365, Looker) or for any provider you'd rather drive with your own OAuth app — see the [BYO flow](#byo-flow-providers-the-broker-doesn-t-carry) below.
+
+::: info Migration note (2026-05)
+Earlier dicode releases shipped per-provider entries `auth/github-oauth`, `auth/google-oauth`, `auth/slack-oauth`, etc. for every broker-backed provider. Those entries were removed once the broker became the source of truth — operators who relied on `/hooks/<provider>-oauth` callbacks for any of the 13 broker-backed providers should switch to the broker flow (no callback URL re-registration needed: the redirect URI lives on the broker, not your daemon). Operators who prefer to keep a self-hosted OAuth app for a specific provider can [instantiate `_oauth-app`](#byo-flow-providers-the-broker-doesn-t-carry) with their own credentials.
+:::
+
 ### How it works
 
 ::: info Prerequisite
@@ -234,6 +242,51 @@ A representative sample of providers the hosted broker at `relay.dicode.app` shi
 
 Self-hosted brokers can add providers by editing `relay.yaml` and restarting — no code change to dicode-core, no daemon redeploy.
 
+### BYO flow - providers the broker doesn't carry
+
+For providers the relay broker doesn't proxy (Office 365 / Microsoft Graph and Looker today), or for any provider you'd rather drive with your own OAuth app, dicode-core ships a generic OAuth task at `tasks/auth/_oauth-app/task.yaml`. You instantiate it from your own taskset with provider-specific overrides — the daemon talks to the provider directly, with credentials you store as secrets.
+
+The default `auth` taskset includes working examples (`office365-oauth`, `looker-oauth`, plus the standalone `openrouter-oauth`). To wire a new provider, copy one of those entries into your own taskset:
+
+```yaml
+# ~/dicode-tasks/taskset.yaml
+apiVersion: dicode/v1
+kind: TaskSet
+metadata:
+  name: my-tasks
+spec:
+  entries:
+    my-google-oauth:
+      ref:
+        path: <path-to-dicode>/tasks/auth/_oauth-app/task.yaml
+      overrides:
+        name: My Google OAuth
+        trigger: { webhook: /hooks/my-google-oauth }
+        params:
+          provider: google
+          scope: "https://www.googleapis.com/auth/gmail.readonly"
+          client_id_env: CLIENT_ID
+          client_secret_env: CLIENT_SECRET
+          access_token_env:  MY_GOOGLE_ACCESS_TOKEN
+          refresh_token_env: MY_GOOGLE_REFRESH_TOKEN
+        env:
+          - { name: CLIENT_ID,               secret: MY_GOOGLE_CLIENT_ID }
+          - { name: CLIENT_SECRET,           secret: MY_GOOGLE_CLIENT_SECRET }
+          - { name: MY_GOOGLE_ACCESS_TOKEN,  secret: MY_GOOGLE_ACCESS_TOKEN,  optional: true }
+          - { name: MY_GOOGLE_REFRESH_TOKEN, secret: MY_GOOGLE_REFRESH_TOKEN, optional: true }
+```
+
+Then store your credentials and click Connect on the dashboard:
+
+```sh
+dicode secret set MY_GOOGLE_CLIENT_ID     <client-id>
+dicode secret set MY_GOOGLE_CLIENT_SECRET <client-secret>
+```
+
+The redirect URI registered with the provider must point at your daemon's webhook for this entry — typically `http://localhost:8080/hooks/my-google-oauth`, or `https://relay.dicode.app/u/<uuid>/hooks/my-google-oauth` if you're going through the relay. BYO works with or without `relay.enabled: true`; the broker is not in the loop for these flows.
+
+The full walkthrough — including the `_oauth-app` parameter reference and a list of provider keys understood by `tasks/auth/_oauth/providers.ts` — lives in the [`tasks/auth/taskset.yaml`](https://github.com/dicode-ayo/dicode-core/blob/main/tasks/auth/taskset.yaml) header in dicode-core.
+
 ### Daemon-side connection status
 
 The dashboard's **Auth providers** panel needs more than the catalogue — it has to show, for each provider, whether the user has already completed the OAuth flow. That join lives in a built-in daemon task, `buildin/auth-providers`, which combines the broker's `/providers` response with the daemon's local secrets store.
@@ -289,7 +342,7 @@ Because the broker is the single source of truth, adding a new provider to `rela
 | | Self-hosted (free) | dicode.app Pro |
 |---|---|---|
 | Webhook relay | Yes (run your own server) | Yes (managed, unlimited) |
-| OAuth broker | No — register your own apps | Yes — 14 providers, zero setup |
+| OAuth broker | No — instantiate `_oauth-app` per provider with your own apps | Yes — 13 providers, zero setup |
 | Custom domain | Your own domain | `*.dicode.app` |
 | Token encryption | N/A | ECIES (P-256 + AES-256-GCM) |
 

--- a/docs-src/getting-started/index.md
+++ b/docs-src/getting-started/index.md
@@ -120,7 +120,7 @@ The wizard pre-wires three git-backed tasksets, all default-on:
 | --- | --- |
 | **Built-in tasks** (`buildin`) | Tray icon, notifications, web UI, dicodai chat, alert. The daemon's standard inventory. |
 | **Examples** (`examples`) | Copy-friendly samples — `hello-cron`, `github-stars`, `webhook-form`, `nginx-start`, and more. |
-| **OAuth providers** (`auth`) | Carries the BYO entries (`office365-oauth`, `looker-oauth`) and the standalone `openrouter-oauth`. With `relay.enabled: true`, the broker handles GitHub, Slack, Google, Spotify, Linear, Discord, GitLab, Airtable, Notion, Confluence, Salesforce, Stripe, and Azure end-to-end — no per-provider entry needed. See [Webhook Relay & OAuth](/concepts/relay#oauth-broker-dicode-app-pro). |
+| **OAuth providers** (`auth`) | Carries the BYO `looker-oauth` entry and the standalone `openrouter-oauth`. With `relay.enabled: true`, the broker handles GitHub, Slack, Google, Spotify, Linear, Discord, GitLab, Airtable, Notion, Confluence, Salesforce, Stripe, Office 365, and Azure end-to-end — no per-provider entry needed. See [Webhook Relay & OAuth](/concepts/relay#oauth-broker-dicode-app-pro). |
 
 The wizard also scaffolds a local tasks directory (default `~/dicode-tasks/`) with a starter `taskset.yaml` so you can drop your own tasks in next to the curated ones.
 

--- a/docs-src/getting-started/index.md
+++ b/docs-src/getting-started/index.md
@@ -120,7 +120,7 @@ The wizard pre-wires three git-backed tasksets, all default-on:
 | --- | --- |
 | **Built-in tasks** (`buildin`) | Tray icon, notifications, web UI, dicodai chat, alert. The daemon's standard inventory. |
 | **Examples** (`examples`) | Copy-friendly samples — `hello-cron`, `github-stars`, `webhook-form`, `nginx-start`, and more. |
-| **OAuth providers** (`auth`) | Zero-paste OAuth tasks for Google, GitHub, Slack, OpenRouter, Spotify, and more. |
+| **OAuth providers** (`auth`) | Carries the BYO entries (`office365-oauth`, `looker-oauth`) and the standalone `openrouter-oauth`. With `relay.enabled: true`, the broker handles GitHub, Slack, Google, Spotify, Linear, Discord, GitLab, Airtable, Notion, Confluence, Salesforce, Stripe, and Azure end-to-end — no per-provider entry needed. See [Webhook Relay & OAuth](/concepts/relay#oauth-broker-dicode-app-pro). |
 
 The wizard also scaffolds a local tasks directory (default `~/dicode-tasks/`) with a starter `taskset.yaml` so you can drop your own tasks in next to the curated ones.
 

--- a/docs-src/index.md
+++ b/docs-src/index.md
@@ -38,8 +38,8 @@ features:
     link: /concepts/relay
     linkText: Webhook relay docs
   - icon: "\U0001F511"
-    title: One-Click OAuth (14 Providers)
-    details: "Click Connect in the UI, authenticate with the provider, token appears in your daemon — encrypted end-to-end. No app registration, no client secrets, no callback URLs. GitHub, Slack, Google, Discord, GitLab, Spotify, Linear, Notion, Stripe, Salesforce, Office 365, Azure AD, Airtable, Confluence."
+    title: One-Click OAuth (13 Providers)
+    details: "Click Connect in the UI, authenticate with the provider, token appears in your daemon — encrypted end-to-end. No app registration, no client secrets, no callback URLs. GitHub, Slack, Google, Discord, GitLab, Spotify, Linear, Notion, Stripe, Salesforce, Azure AD, Airtable, Confluence — plus a BYO instantiation path for any provider the broker doesn't carry."
     link: /concepts/relay
     linkText: OAuth broker docs
   - icon: "\U0001F6E1"


### PR DESCRIPTION
## Summary

Mirrors the auth-X consolidation shipping in [dicode-core#277](https://github.com/dicode-ayo/dicode-core/pull/277) onto the docs site.

dicode-core#277 removes 13 per-provider OAuth entries (`auth/github-oauth`, `auth/google-oauth`, `auth/slack-oauth`, …) — the relay broker (>= 0.1.5) now hosts the OAuth app credentials and runs the full PKCE handshake end-to-end via `buildin/auth-{providers,start,relay}`. `auth/_oauth-app/task.yaml` is reframed as the public BYO entry point: operators instantiate it from their own taskset for any provider the broker doesn't carry (today: `office365`, `looker`).

- **`docs-src/concepts/relay.md`** — add the consolidation framing to the OAuth Broker section, a copy-pasteable BYO walkthrough for any user-supplied provider, and a 2026-05 migration note for operators with self-hosted callback URLs at deleted `/hooks/<provider>-oauth` endpoints. Update the Self-hosted-vs-Pro table ("14 providers" → "13 providers"; the self-hosted column now points at the BYO `_oauth-app` flow rather than implying no path exists).
- **`docs-src/index.md`** — hero card "One-Click OAuth" now reads "13 Providers" (Azure AD stays in the broker; Office 365 moves to BYO) and the details mention the BYO instantiation path for anything outside the broker catalogue.
- **`docs-src/getting-started/index.md`** — the curated-tasksets row for `auth` now reflects the new shape: it carries `office365-oauth`, `looker-oauth`, and `openrouter-oauth`, while the broker handles the 13 broker-backed providers end-to-end with `relay.enabled: true`.

## Migration note

Operators on older releases who registered OAuth callback URLs against deleted `/hooks/<provider>-oauth` endpoints for any of the 13 broker-backed providers should switch to the broker flow (no callback URL re-registration needed — the redirect URI lives on the broker, not the daemon). Operators who'd rather drive a specific provider with their own OAuth app can copy one of the BYO entries (`office365-oauth`, `looker-oauth`) as a starting point.

## Merge order

This should merge **after** [dicode-core#277](https://github.com/dicode-ayo/dicode-core/pull/277). Until that lands, the public `tasks/auth/taskset.yaml` still ships the per-provider entries this PR says are gone.

## Test plan

- [x] `npm run build:docs` — VitePress build passes.
- [x] All inline anchors resolve in the rendered HTML (`#oauth-broker-dicode-app-pro`, `#byo-flow-providers-the-broker-doesn-t-carry`).
- [ ] Reviewer eyeballs the OAuth Broker section in `concepts/relay.md` for accuracy against `dicode-core/docs/oauth.md` on `refactor/auth-consolidation`.
- [ ] Reviewer confirms the BYO walkthrough matches the header of `dicode-core/tasks/auth/taskset.yaml` on `refactor/auth-consolidation`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>