### PR TITLE
docs: drop legacy notification config; document task-based path

### DIFF
--- a/docs-src/concepts/sources.md
+++ b/docs-src/concepts/sources.md
@@ -125,7 +125,7 @@ The override system can patch these fields without modifying the original `task.
 - `net` (replace network access list)
 - `timeout`
 - `runtime`
-- `notify` (`on_success`, `on_failure`)
+- `on_failure_chain` (override which task fires on failure, including notifications)
 - `dicode` permissions (`tasks`, `mcp`, `list_tasks`, `get_runs`, `secrets_write`)
 - `enabled` (see below)
 

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -131,7 +131,7 @@ docker:                          # docker/podman runtime only
 
 timeout: 30s                     # default 60s for script tasks; no default for docker/daemon
 mcp_port: 3000                   # daemon exposes MCP server on this port
-on_failure_chain: alert-task     # short form — task to run on failure
+on_failure_chain: buildin/alert  # short form — task to run on failure
 # or the structured form:
 # on_failure_chain:
 #   task: buildin/auto-fix
@@ -139,10 +139,6 @@ on_failure_chain: alert-task     # short form — task to run on failure
 #   cooldown: 10m
 #   max_concurrent: 1
 #   max_depth: 2
-
-notify:
-  on_success: false
-  on_failure: true
 ```
 
 ## Field reference
@@ -164,8 +160,7 @@ notify:
 | `docker` | object | conditional | Required when runtime is `docker` or `podman` |
 | `timeout` | duration | no | Max execution time (default `60s` for scripts) |
 | `mcp_port` | int | no | Port where a daemon task exposes an MCP server |
-| `on_failure_chain` | string \| object | no | Task ID (short form) or structured block to trigger on failure. See [Auto-fix loop](./auto-fix.md). |
-| `notify` | object | no | Notification overrides |
+| `on_failure_chain` | string \| object | no | Task ID (short form) or structured block to trigger on failure. Used for notifications, auto-fix, and any other side-effect chain. See [Auto-fix loop](./auto-fix.md). |
 
 ### Trigger types
 

--- a/docs-src/examples/docker-task.md
+++ b/docs-src/examples/docker-task.md
@@ -122,8 +122,8 @@ dicode manages the full container lifecycle:
   unexpectedly, orphaned containers are detected and cleaned up on the
   next startup. Containers are labeled with dicode metadata for tracking.
 - **Exit codes** -- The container's exit code becomes the task run's exit
-  code. Non-zero exits are treated as failures and trigger `notify.on_failure`
-  if configured.
+  code. Non-zero exits are treated as failures and fire
+  `on_failure_chain` if one is configured at the task or `defaults` level.
 
 ## Using Podman instead of Docker
 

--- a/docs-src/getting-started/configuration.md
+++ b/docs-src/getting-started/configuration.md
@@ -168,8 +168,8 @@ Two buildins are shipped out of the box:
 
 | Task | Surface | Notes |
 |---|---|---|
-| `buildin/notify` | Native OS desktop notification (`notify-send` / `osascript` / `powershell`) | No external service. Works offline. |
-| `buildin/alert` | Wrapper that calls `buildin/notify` via `dicode.run_task` | Demonstrates the chain pattern; copy and adapt for ntfy / Slack / Discord / email / etc. |
+| `buildin/notifications` | Native OS desktop notification (`notify-send` / `osascript` / `powershell`) | No external service. Works offline. |
+| `buildin/alert` | Wrapper that calls `buildin/notifications` via `dicode.run_task` | Demonstrates the chain pattern; copy and adapt for ntfy / Slack / Discord / email / etc. |
 
 For mobile push (ntfy.sh, gotify, pushover, telegram), webhook integrations (Slack, Discord), or any custom delivery, write a task that POSTs to the right endpoint and point `defaults.on_failure_chain` at it. Per-task overrides go through the task-level `on_failure_chain` field — see [Tasks → on_failure_chain](/concepts/tasks#field-reference).
 

--- a/docs-src/getting-started/configuration.md
+++ b/docs-src/getting-started/configuration.md
@@ -44,14 +44,6 @@ secrets:
     - type: local
     - type: env
 
-notifications:
-  on_failure: true
-  on_success: false
-  provider:
-    type: ntfy
-    url: https://ntfy.sh
-    topic: dicode-alerts
-
 server:
   port: 8080
   auth: false
@@ -69,7 +61,7 @@ ai:
   base_url: ""
 
 defaults:
-  on_failure_chain: ""
+  on_failure_chain: buildin/alert
 
 relay:
   enabled: false
@@ -170,18 +162,16 @@ The `env` provider reads directly from environment variables.
 
 ## Notifications
 
-```yaml
-notifications:
-  on_failure: true          # notify on task failure (default: true)
-  on_success: false         # notify on task success (default: false)
-  provider:
-    type: ntfy              # "ntfy", "gotify", "pushover", or "telegram"
-    url: https://ntfy.sh    # provider base URL
-    topic: dicode-alerts    # ntfy topic / gotify app token / etc.
-    token_env: NTFY_TOKEN   # env var holding auth token (optional)
-```
+Notifications are delivered by **tasks**, not by a daemon-level config block. Wire any notification path you like by pointing `defaults.on_failure_chain` at a task that emits the alert — see the [Defaults](#defaults) section below.
 
-Individual tasks can override notification settings with the `notify` field in `task.yaml`.
+Two buildins are shipped out of the box:
+
+| Task | Surface | Notes |
+|---|---|---|
+| `buildin/notify` | Native OS desktop notification (`notify-send` / `osascript` / `powershell`) | No external service. Works offline. |
+| `buildin/alert` | Wrapper that calls `buildin/notify` via `dicode.run_task` | Demonstrates the chain pattern; copy and adapt for ntfy / Slack / Discord / email / etc. |
+
+For mobile push (ntfy.sh, gotify, pushover, telegram), webhook integrations (Slack, Discord), or any custom delivery, write a task that POSTs to the right endpoint and point `defaults.on_failure_chain` at it. Per-task overrides go through the task-level `on_failure_chain` field — see [Tasks → on_failure_chain](/concepts/tasks#field-reference).
 
 ## Server
 
@@ -255,10 +245,10 @@ The AI config is used for task generation features. It supports any OpenAI-compa
 
 ```yaml
 defaults:
-  on_failure_chain: notify-on-failure  # task ID to fire when any task fails
+  on_failure_chain: buildin/alert      # task ID to fire when any task fails
 ```
 
-The `on_failure_chain` field specifies a task to trigger whenever another task fails. Individual tasks can override this with the `on_failure_chain` field in `task.yaml`, or disable it with an empty string.
+The `on_failure_chain` field specifies a task to trigger whenever another task fails. This is the primary hook for notifications — point it at `buildin/alert` for desktop notifications, or at any task you write yourself for ntfy / Slack / email / custom delivery. Individual tasks can override this with the `on_failure_chain` field in `task.yaml`, or disable it with an empty string. See [Auto-fix loop](/concepts/auto-fix) for chain-related guardrails (cooldown, concurrency caps, storm circuit breaker).
 
 ## Relay
 


### PR DESCRIPTION
## Summary

- Remove the daemon-level `notifications:` config block from [getting-started/configuration.md](docs-src/getting-started/configuration.md) (top YAML example + dedicated section).
- Replace it with a task-based explanation: notifications are delivered by tasks wired via `defaults.on_failure_chain`. Documents the two shipped buildins (`buildin/notify` for native desktop, `buildin/alert` as a chain wrapper).
- Drop the per-task `notify` field from [concepts/tasks.md](docs-src/concepts/tasks.md) and [concepts/sources.md](docs-src/concepts/sources.md) (override field list).
- Fix [examples/docker-task.md](docs-src/examples/docker-task.md) reference to `notify.on_failure` → `on_failure_chain`.

## Why

The legacy `notifications:` block (`pkg/notify`, `cfg.Notifications.Provider`) duplicates what `defaults.on_failure_chain` + a notification task already does, locks users into a hardcoded ntfy/gotify/pushover/telegram list, and confuses the docs by presenting two ways to do the same thing. Tracking issue dicode-ayo/dicode-core#279 covers the code removal; this PR aligns the docs ahead of that change so we stop pointing new users at the deprecated path.

## Test plan

- [x] `npm run build:docs` — clean build (vitepress 1.6.4, 6.81s)
- [x] `grep -rn 'notifications:\|notify:' docs-src/` — no remaining references except `fsnotify` (unrelated)
- [ ] Reviewer confirms `defaults.on_failure_chain: buildin/alert` is the right canonical example

🤖 Generated with [Claude Code](https://claude.com/claude-code)