### PR TITLE
docs(site): sync triggers + tasks for preflight-pipelines epic

### DIFF
--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -174,6 +174,8 @@ Exactly one trigger type must be configured per task.
 | **Chain** | `chain: { from: task-id, on: success }` | Fires after another task completes |
 | **Daemon** | `daemon: true` | Long-running process, started with the service |
 
+Any trigger type can also declare a `trigger.before:` **preflight pipeline** — a sequential list of one-shot prereq tasks that must succeed before the main body runs. See [Triggers → Preflight pipelines](./triggers.md#preflight-pipelines).
+
 ### Enable / disable
 
 Every task has an `enabled` flag (default `true`). Disabled tasks remain visible in the API and the registry but are **not** scheduled, **not** spawned (daemons), and **not** routed (webhooks).

--- a/docs-src/concepts/triggers.md
+++ b/docs-src/concepts/triggers.md
@@ -305,3 +305,95 @@ docker:
 ```
 
 Daemon tasks have no default timeout -- they run until stopped.
+
+### Daemon states
+
+Daemons cycle through a small set of states observable in the dashboard and via the REST API's `daemon_state` field:
+
+| State | Meaning |
+| --- | --- |
+| `stopped` | Resting state (clean exit). Either deliberately stopped, never started, or ran to completion with `status: success` and no restart configured. |
+| `prereq_running` | The `trigger.before` preflight pipeline is executing. |
+| `prereq_failed` | A preflight stage returned a non-success status. The daemon will not start until the failing stage is re-fired successfully. |
+| `running` | The daemon body is executing. |
+| `stopping` | The engine is shutting the daemon down (operator unregister or engine shutdown). |
+| `failed_after_preflight` | Preflight succeeded, but the daemon's own dispatch errored (binary missing, port already bound, etc.). Terminal — re-fire the daemon to retry. |
+| `crashed` | The daemon's body ran but exited non-success and the restart policy isn't going to restart it. Distinct from `stopped` so clean exits and crashes are visibly different. Terminal — re-fire the daemon to retry. |
+
+---
+
+## Preflight pipelines
+
+Any trigger type — daemon, manual, cron, webhook, or chain — can declare a `trigger.before:` pipeline of one-shot prereq tasks that must succeed before the main task body runs. Stages run **sequentially in declaration order**, and each stage's return value is piped to the next via `${input.output}`. If any stage fails, the pipeline short-circuits and the main body does not run.
+
+```yaml
+trigger:
+  daemon: true
+  restart: always
+  before:
+    # Stage 1: render config from secrets + literal values.
+    - task: buildin/template
+      overrides:
+        params:
+          template: |
+            base_url: ${BASE_URL}
+            password: ${STATUS_PASSWORD}
+        env:
+          - name: BASE_URL
+            value: "https://relay.example.com"
+          - name: STATUS_PASSWORD
+            from: task:secret-providers/doppler
+
+    # Stage 2: persist stage 1's rendered output to disk.
+    - task: buildin/write-local
+      overrides:
+        params:
+          content: "${input.output}"
+          path: "${DATADIR}/relay/relay.yaml"
+          mode: "0600"
+        fs:
+          - path: "${DATADIR}/relay"
+            permission: rw
+```
+
+Each `before[]` entry can be a bare task-ID string or a `{task, overrides}` mapping. Per-edge overrides accept the same conservative subset as `trigger.chain.overrides` (`params`, `env`, `net`, `fs`, `timeout`, `dicode`, `runtime` — not `trigger`, `enabled`, `name`, etc.). Forms can be mixed within the same list.
+
+The engine re-fires every stage on every preflight attempt — there's no "already-satisfied" short-circuit — because the point of preflight is to refresh ephemeral state (rendered configs, freshly rotated credentials) right before the body runs.
+
+**Run-row semantics on failure:**
+
+- **Daemon** — preflight failure leaves the daemon in `prereq_failed` and no daemon-body run is created.
+- **One-shot** (manual / cron / webhook / chain) — preflight + body collapse into a single parent run row. Preflight failure surfaces as `status=failure` with `fail_reason="preflight_failed: stage N (<task-id>): <error>"`.
+
+Preflight stages run as their own child runs tagged `trigger_source=preflight`, linked back to the parent fire — the dashboard groups them under the parent for visibility.
+
+### `${input.output}` interpolation
+
+Three reference shapes are recognised at dispatch time in `before[i].overrides.params` defaults and `trigger.chain.params` values:
+
+| Form | Resolves to |
+| --- | --- |
+| `${input.output}` | upstream's full string return value |
+| `${input.output.<field>}` | named string field of an object-shaped upstream return (e.g. `{path: "..."}`) |
+| `${input.params.<name>}` | named entry from the upstream's `RunOptions.Params` (chain edge only — preflight edges run with empty params) |
+
+Embedded forms (`"prefix-${input.output}-suffix"`) and multi-token forms (`"${input.params.scheme}://${input.output.host}"`) work too — any string containing one or more recognised tokens is rewritten in place. The `<field>` / `<name>` portion accepts letters, digits, underscores, hyphens, and dots, so common shapes like `${input.params.x-forwarded-for}` and `${input.output.db.host}` work without escapes.
+
+References that can't be resolved at dispatch time fail loud — the chain or preflight dispatch is skipped rather than passing a literal token to the downstream. Unknown shapes (e.g. `${input.foo}`) are rejected at task-registration time with a site-qualified error so misuse surfaces at config-load.
+
+The first stage (`before[0]`) has no upstream return value, so any `${input.…}` reference there is rejected at registration. Use a literal default or an env-projected secret on stage 0; downstream stages can then pipe via `${input.output}`.
+
+### Mid-pipeline re-fire (daemon-only)
+
+When an intermediate stage at index `i` re-runs successfully — e.g. an operator manually fires `buildin/template` to pick up a rotated secret — the engine re-fires stages `[i+1..n-1]` with the re-run's fresh return value as the initial `${input.output}`, then restarts the daemon to pick up the propagated config. Propagations are coalesced per daemon (at most one in flight) so a flurry of upstream completions produces a single re-render + restart, not a thrash loop. One-shots don't auto-restart on a prereq re-run — re-fire the one-shot yourself if you want it to re-run.
+
+### Registration-time validation
+
+The engine rejects at registration:
+
+- References to unknown tasks.
+- References to daemons (only one-shot tasks can be preflights).
+- Self-references and cycles in the before-graph (e.g. `A.before: [B]; B.before: [A]`).
+- `${input.params.<name>}` on any `before[]` edge — preflight stages run with empty `RunOptions`, so the upstream params channel is statically unavailable.
+
+For an end-to-end example combining daemon preflight, per-edge overrides, `${DATADIR}` volumes, and secret rotation, see the [Cloudflare Tunnel worked example](https://github.com/dicode-ayo/dicode-core/blob/main/docs/examples/cloudflare-tunnel.md) in dicode-core.


### PR DESCRIPTION
## Summary

Syncs the public dicode-site docs with the dicode-core preflight-pipelines epic that just landed on main:

- **triggers.md** — adds a "Preflight pipelines" section covering `trigger.before:` on every trigger type, the `${input.output}` / `${input.params}` interpolation grammar, mid-pipeline re-fire propagation, and registration-time validation. Adds a "Daemon states" subsection covering `prereq_running`, `prereq_failed`, `failed_after_preflight`, and `crashed` alongside the existing `stopped` / `running` / `stopping` states.
- **tasks.md** — adds a one-line pointer from the trigger-types table to the new preflight-pipelines section.

Source PRs in dicode-core: [#309](https://github.com/dicode-ayo/dicode-core/pull/309) (`buildin/write-local`), [#310](https://github.com/dicode-ayo/dicode-core/pull/310) (`${input.output}`), [#311](https://github.com/dicode-ayo/dicode-core/pull/311) (sequential `trigger.before`), [#321](https://github.com/dicode-ayo/dicode-core/pull/321) (cloudflared example backfit), [#323](https://github.com/dicode-ayo/dicode-core/pull/323) (`template_path`), [#324](https://github.com/dicode-ayo/dicode-core/pull/324) (`failed_after_preflight`), [#328](https://github.com/dicode-ayo/dicode-core/pull/328) (relay-server `template_path`), [#329](https://github.com/dicode-ayo/dicode-core/pull/329) (`crashed`), [#330](https://github.com/dicode-ayo/dicode-core/pull/330) (richer `${input.*}` grammar), [#331](https://github.com/dicode-ayo/dicode-core/pull/331) (one-shot `trigger.before`).

## Punch list checked

| Item | Status |
|---|---|
| `triggers.md` — preflight pipelines | added |
| `triggers.md` — `${input.output}` grammar | added |
| `triggers.md` — daemon states (prereq_running, prereq_failed, failed_after_preflight, crashed) | added |
| `tasks.md` — cross-reference to preflight section | added |
| `tasks.md` — `notify:` field already dropped in #54 | current |
| `configuration.md` — daemon-level `notifications:` block already dropped in #54 | current |
| Landing `dc-everything-task` — "Notifications" still listed as a platform task | current (now delivered by `buildin/notifications`) |
| `docs/docs/hashmap.json` — regenerated by `npm run build` (vitepress local search index) | current (rebuild on deploy) |

## Not in scope

- A dedicated `examples/cloudflare-tunnel.md` page would be a natural follow-up but doesn't fit the existing simple-examples set; flagging as a possible follow-up rather than introducing it here.
- The landing copy already covers "everything is a task" + "chain return values into the next input"; preflight pipelines are an internal-grammar detail that doesn't materially change the operator narrative on the landing page.

## Test plan

- [x] `npm run build` succeeds (vite + vitepress)
- [ ] Manual visual review of `/docs/concepts/triggers#preflight-pipelines` after deploy
- [ ] Cross-link from `/docs/concepts/tasks` trigger-types table resolves to the new heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)