### PR TITLE
docs: document kind: PipelineTask

### DIFF
--- a/docs-src/.vitepress/config.ts
+++ b/docs-src/.vitepress/config.ts
@@ -64,6 +64,7 @@ export default defineConfig({
           { text: "Tasks", link: "/concepts/tasks" },
           { text: "Runtimes", link: "/concepts/runtimes" },
           { text: "Triggers", link: "/concepts/triggers" },
+          { text: "Pipelines", link: "/concepts/pipelines" },
           { text: "SDK Globals", link: "/concepts/sdk" },
           { text: "Secrets", link: "/concepts/secrets" },
           { text: "Sources & TaskSets", link: "/concepts/sources" },

--- a/docs-src/concepts/pipelines.md
+++ b/docs-src/concepts/pipelines.md
@@ -1,0 +1,321 @@
+# Pipelines (`kind: PipelineTask`)
+
+A **pipeline** is a `kind: PipelineTask` that declares an ordered list of **stages**. Each stage is an existing `kind: Task`, run as its own child run. A stage must reach `status: success` for the pipeline to advance; the first failure short-circuits the rest. The previous stage's return value is piped forward via `${input.output}`, so the **render → persist → start-daemon** composition lives in one self-contained pipeline definition.
+
+::: info Replaces `trigger.before`
+Pipelines replace the old `trigger.before:` preflight list. Preflight orchestration is no longer a list bolted onto a task — it's a first-class `kind: PipelineTask` whose stages run sequentially before a terminal daemon/body stage. A `task.yaml` that still declares `trigger.before` is **rejected at load**. See [Migrating from `trigger.before`](#migrating-from-trigger-before).
+:::
+
+A pipeline lives in a task folder like any other task — the file is still **`task.yaml`**, discriminated by its `kind:`. There is no separate filename; the loader reads `kind: PipelineTask` and parses the pipeline schema instead of the `kind: Task` schema.
+
+```yaml
+apiVersion: dicode/v1
+kind: PipelineTask
+name: Render and Serve
+description: Render config, persist it, then run the daemon body.
+subtype: sequential
+
+trigger:
+  manual: true        # how the PIPELINE is fired (optional)
+
+stages:
+  - task: buildin/template       # stage 1: render
+    overrides:
+      params:
+        - name: template_path
+          default: "${TASK_DIR}/config.tmpl"
+  - task: buildin/write-local    # stage 2: persist stage 1's output
+    overrides:
+      params:
+        - name: content
+          default: "${input.output}"
+        - name: path
+          default: "${DATADIR}/app/config.yml"
+      fs:
+        - path: "${DATADIR}/app"
+          permission: rw
+  - task: app-daemon-body        # terminal stage: a kind: Task daemon
+```
+
+## Pipeline fields
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `apiVersion` | string | yes | Must be `dicode/v1` |
+| `kind` | string | yes | Must be `PipelineTask` |
+| `name` | string | yes | Human-readable pipeline name |
+| `description` | string | no | One-line (or multi-line) description |
+| `subtype` | string | yes | Must be `sequential` in v1. Any other value (e.g. `parallel`) is rejected at load — parallel pipelines are a planned follow-up. |
+| `trigger` | object | no | How the **pipeline** is fired. At most one trigger type. Omit for a pipeline that's only fired programmatically (e.g. via `dicode.run_task`). |
+| `trigger.manual` | bool | no | Manual-only fire (API / UI) |
+| `trigger.cron` | string | no | Standard 5-field cron expression |
+| `trigger.webhook` | string | no | Webhook path, e.g. `/deploy` |
+| `trigger.webhook_secret` | string | no | HMAC secret for the webhook (supports `${VAR}` expansion) |
+| `trigger.auth` | bool | no | Require a valid dicode session for the webhook (same semantics as `kind: Task`) |
+| `trigger.chain` | object | no | Chain trigger — fire the pipeline when an upstream task/pipeline completes |
+| `stages` | list | yes | Ordered list of stages; at least one required |
+| `stages[].task` | string | yes | Task ID of an existing `kind: Task` to run as this stage |
+| `stages[].overrides` | object | no | Per-stage patch applied to the stage task's spec at dispatch time (see [Stage overrides](#stage-overrides)) |
+| `timeout` | duration | no | Overall pipeline timeout (e.g. `5m`). Cancels the in-flight stage and fails the pipeline if exceeded. |
+
+::: warning No `trigger.daemon` on a pipeline
+A pipeline does **not** have a daemon trigger. It becomes daemon-shaped *implicitly* when its **terminal stage** is a `kind: Task` with `trigger.daemon: true` — see [Daemon terminal stage](#daemon-terminal-stage).
+:::
+
+A pipeline accepts `manual`, `cron`, `webhook` (with optional `webhook_secret` / `auth`), and `chain`. It does **not** accept `daemon`. As with `kind: Task`, at most one trigger type may be set.
+
+## Sequential semantics
+
+`subtype: sequential` runs the stages in declaration order:
+
+1. Each non-terminal stage is fired as a child run and the pipeline **waits for it to reach `success`** before advancing.
+2. The stage's return value is threaded into the next stage as `${input.output}` (see [Stage input threading](#stage-input-threading)).
+3. The first stage to reach `failure` / `timeout` / `cancelled` **short-circuits** the pipeline: the remaining stages are never fired, the pipeline's run goes to `failure`, and `fail_reason` is set to `stage N (<task-id>): <error>` (N is **0-based**, so the first stage failing reports `stage 0 (...)`).
+
+## Stage input threading
+
+Stages share the same `${input.…}` interpolation grammar as [chain params](./triggers.md#chain), evaluated at dispatch time against the **previous stage's** output:
+
+| Form | Resolves to |
+| --- | --- |
+| `${input.output}` | the previous stage's full string return value |
+| `${input.output.<field>}` | a named string field of an object-shaped previous-stage return (e.g. `{path: "..."}`) |
+
+These tokens are used inside `stages[].overrides.params` defaults (and the other override string fields). Empty strings are treated as "not provided": a token that would resolve to an empty string **fails the stage loudly** (`ErrInputUnavailable`) rather than substituting silently. Embedded forms (`"prefix-${input.output}-suffix"`) and multi-token forms work too. The `<field>` portion accepts letters, digits, underscores, hyphens, and dots — so `${input.output.db.host}` works without escapes.
+
+::: warning v1 threads `Output` only
+`${input.params.<name>}` (referencing the *upstream stage's* input params) is **not** supported in sequential pipelines and is rejected at load on every stage. Cross-stage param threading is a planned follow-up; for now, thread data forward through each stage's **return value** (`${input.output}`).
+:::
+
+::: warning The first stage receives no input
+Any `${input.…}` reference in `stages[0].overrides` is rejected at load — there is no upstream stage to resolve it against. Use a literal default or an env-projected secret on stage 0.
+:::
+
+## Stage overrides
+
+A stage may carry an `overrides:` block that patches a **deep copy** of the stage task's spec at dispatch time — the underlying `kind: Task` is untouched, so a manual / cron / chain fire of that same task is unaffected. Stage overrides accept a slightly **wider** allowlist than `trigger.chain.overrides`: crucially, a stage **may override the stage task's `trigger`**.
+
+| Field | Allowed at a pipeline stage? |
+| --- | --- |
+| `params`, `env`, `net`, `fs`, `timeout`, `dicode`, `runtime` | yes |
+| `trigger` | **yes** (unlike chain edges) — e.g. flip the terminal stage's `daemon`-ness |
+| `enabled`, `name`, `description`, `retry`, `defaults`, `entries` | no (rejected at load) |
+
+A stage runs **regardless of the stage task's own trigger type**: the engine dispatches the merged stage spec directly and never gates on whether the underlying `kind: Task` is `manual` / `cron` / etc. So a `manual: true` library task fires as a stage with **no** trigger override — for example the shipped `buildin/relay-server` pipeline fires `buildin/write-local` (which is `trigger.manual: true`) as a stage and overrides only `params` / `fs` / `timeout`, never `trigger`.
+
+The `trigger` override is allowed at a stage so a stage can flip **daemon-ness** — set or clear `daemon: true` on the merged spec to make (or unmake) the terminal stage a daemon:
+
+```yaml
+stages:
+  - task: my-server-task
+    overrides:
+      trigger:
+        daemon: true    # make this the pipeline's terminal daemon stage
+```
+
+## Daemon terminal stage
+
+If the **last** stage is a `kind: Task` with `trigger.daemon: true`, the pipeline is *daemon-shaped*: its lifetime is tied to the daemon's run.
+
+- The render/persist stages run to `success` as usual, then the daemon stage is fired **without** a wait-to-success gate.
+- The pipeline's run stays **`running`** for as long as the daemon's run is `running`.
+- When the daemon run terminates, the pipeline's run terminates with the **daemon's actual status** — `success`, `failure`, or `cancelled`.
+- **Killing or cancelling the pipeline** (`POST /api/runs/{id}/kill`, or the engine cancelling the parent run) propagates to the live daemon stage: the daemon run transitions to `cancelled`, which becomes the pipeline's terminal status.
+
+Whether the terminal stage is a daemon is decided from the **merged** dispatch spec — a stage `trigger` override can flip daemon-ness either way.
+
+### Re-rendering a live daemon
+
+Re-firing any non-terminal stage of a *live* pipeline (e.g. an operator runs `buildin/template` directly to pick up rotated secrets) replays the descendant stages with fresh `${input.…}` and then restarts the terminal daemon so it adopts the freshly-rendered files. No pipeline restart or app restart is needed. Restarts are coalesced (at most one in flight per pipeline) so a flurry of rotations produces one re-render and one restart, not a thrash loop.
+
+## Status semantics
+
+| Situation | Pipeline run status |
+| --- | --- |
+| All stages succeed, terminal stage is **not** a daemon | `success` (return value = terminal stage's return) |
+| All stages succeed, terminal stage **is** a daemon | `running` while the daemon runs, then the daemon's terminal status |
+| Any stage reaches `failure` / `timeout` / `cancelled` | `failure`, with `fail_reason: stage N (<task-id>): <error>`; later stages never fire |
+| Pipeline killed / cancelled while the daemon runs | `cancelled` |
+| Overall `timeout:` exceeded | `failure` (the in-flight stage is cancelled) |
+
+A pipeline's own return value is the **terminal stage's** return value, persisted to the parent run row the same way a `kind: Task`'s is — so chain consumers and `dicode.run_task` callers observe it. (The terminal stage's [`run_result.enabled: false`](./secrets.md) propagates, suppressing persistence of secret-bearing returns.)
+
+## How pipeline runs appear
+
+Each pipeline fire produces **N+1** run rows:
+
+- One **parent** run with `kind=pipeline` (the pipeline's own run).
+- One **child** run per stage, each `kind=task`, linked by `parent_run_id`, with `trigger_source=pipeline-stage`.
+
+The dashboard lists runs per task. A pipeline fire shows up as the parent run on the pipeline's own task; drill into it to see its stage children grouped under the parent with their individual statuses. A daemon stage that fails shows up as a `failure` child under a `failure` pipeline parent.
+
+## Pipeline vs. chain — when to use which
+
+`kind: PipelineTask` does **not** replace `trigger.chain` (see [Triggers → Chain](./triggers.md#chain)). They model orthogonal orchestration concerns and coexist:
+
+| Concern | Pipeline (`kind: PipelineTask`) | Chain (`trigger.chain`) |
+| --- | --- | --- |
+| Coupling direction | The pipeline declares the sequence; stages don't know they're in one | The downstream declares its dependency on an upstream; the upstream is unaware |
+| Style | Procedural — one file describes the whole flow | Event-driven / observer |
+| Discoverability | Read one spec → see the entire flow | Scan the task graph for `chain.from: A`; fan-out is implicit |
+| Coordination | One team owns the pipeline file | One team can react to another's task without editing it |
+| Cardinality | One pipeline, N ordered stages | One source, M downstream subscribers (natural fan-out) |
+| Failure semantics | A stage failure short-circuits the pipeline | `on_failure_chain` lets a separate task react to failure |
+
+**Reach for a pipeline** when you own the whole sequence and want it described in one place — especially the render → persist → start-daemon shape that `trigger.before` used to express.
+
+**Reach for a chain** when:
+
+1. **Decoupled observability/auditing** — task A runs; audit-task B chains from it without modifying A or every consumer of A.
+2. **Failure remediation** — `on_failure_chain` runs B only when A fails; pipelines have no "run only if failed" grammar yet.
+3. **Cross-team coordination** — team Y fires B when team X's task A completes, without coordinating a shared pipeline file.
+4. **Many-to-one aggregation** — task C reacts when any of {A, B, D} completes (C has a `chain.from` on each).
+
+**They compose, too:**
+
+- **Chain → pipeline:** a `kind: PipelineTask` with `trigger.chain.from: <task>` fires when the upstream completes; the first stage receives the upstream's return via the same `${input.…}` grammar.
+- **Pipeline → chain:** another task's `trigger.chain.from: <pipeline-id>` fires when the pipeline's **overall** run terminates (not on individual stage completion).
+- **Stage-level `on_failure_chain`** still fires: a stage is a `kind: Task`, so its own configured failure chain fires when that stage fails, independent of the pipeline's short-circuit.
+
+## Migrating from `trigger.before`
+
+`trigger.before` declared a list of preflight steps that ran before a task's daemon/body. The replacement splits that into two pieces:
+
+1. A standalone **daemon-body** `kind: Task` (`trigger.daemon: true`) — the thing that used to host `trigger.before`. It reads its pre-rendered config off disk and is independently runnable.
+2. A **`kind: PipelineTask`** whose render/persist stages run first and whose **terminal stage** is that daemon-body task.
+
+The mechanical conversion:
+
+| Old (`trigger.before`) | New (`kind: PipelineTask`) |
+| --- | --- |
+| The host task with `trigger.daemon: true` | A standalone `kind: Task` daemon body (its own folder) |
+| Each `before[i]` entry | A `stages[i]` entry referencing the same task ID, with the same overrides |
+| `${input.output}` between before-steps | `${input.output}` between stages (unchanged) |
+| The daemon as the implicit "after" step | The daemon body as the **terminal** stage |
+
+### Worked example: `buildin/relay-server`
+
+**Before** — a single daemon task with a `trigger.before` preflight (the shape that is now rejected at load):
+
+```yaml
+# tasks/buildin/relay-server/task.yaml  (OLD — no longer valid)
+apiVersion: dicode/v1
+kind: Task
+name: Relay Server
+runtime: deno
+
+trigger:
+  daemon: true
+  restart: always
+  before:
+    - task: buildin/template          # render relay.yaml from Doppler-fed env
+      overrides:
+        params:
+          - name: template_path
+            default: "${TASK_DIR}/relay.yaml"
+        fs:
+          - path: "${TASK_DIR}/relay.yaml"
+            permission: r
+        env:
+          - name: BASE_URL
+            value: "https://relay.example.com"
+          # ...Doppler-fed OAuth client_id/secret entries...
+    - task: buildin/write-local       # persist the rendered string
+      overrides:
+        params:
+          - name: content
+            default: "${input.output}"
+          - name: path
+            default: "${DATADIR}/relay/relay.yaml"
+          - name: mode
+            default: "0600"
+        fs:
+          - path: "${DATADIR}/relay"
+            permission: rw
+
+permissions:
+  net: ["*"]
+  fs:
+    - path: "${DATADIR}/relay"
+      permission: rw
+```
+
+**After** — a `kind: PipelineTask` (`task.yaml`) whose terminal stage is a standalone daemon-body `kind: Task`:
+
+```yaml
+# tasks/buildin/relay-server/task.yaml  (NEW — kind: PipelineTask)
+apiVersion: dicode/v1
+kind: PipelineTask
+name: Relay Server
+description: Render relay.yaml from Doppler-fed env, then run the relay daemon.
+subtype: sequential
+
+stages:
+  - task: buildin/template            # stage 1: render
+    overrides:
+      timeout: 30s
+      params:
+        - name: template_path
+          default: "${TASK_DIR}/relay.yaml"
+      fs:
+        - path: "${TASK_DIR}/relay.yaml"
+          permission: r
+      env:
+        - name: BASE_URL
+          value: "https://relay.example.com"
+        # ...Doppler-fed OAuth client_id/secret entries...
+
+  - task: buildin/write-local         # stage 2: persist stage 1's output
+    overrides:
+      timeout: 30s
+      params:
+        - name: content
+          default: "${input.output}"
+        - name: path
+          default: "${DATADIR}/relay/relay.yaml"
+        - name: mode
+          default: "0600"
+      fs:
+        - path: "${DATADIR}/relay"
+          permission: rw
+
+  - task: buildin/relay-server-body   # terminal stage: the daemon
+```
+
+```yaml
+# tasks/buildin/relay-server-body/task.yaml  (NEW — standalone daemon body)
+apiVersion: dicode/v1
+kind: Task
+name: Relay Server (daemon body)
+description: Runs the relay daemon, reading the pre-rendered relay.yaml off disk.
+runtime: deno
+
+trigger:
+  daemon: true
+  restart: always
+
+permissions:
+  net: ["*"]
+  fs:
+    - path: "${DATADIR}/relay"
+      permission: rw
+  env:
+    - DICODE_DATADIR
+    - DICODE_VERSION
+```
+
+What changed and why:
+
+- The daemon body is now a plain `kind: Task` that **reads** the pre-rendered config — it's independently runnable and carries no rendering concern. OAuth secrets and the status password are scoped to the render stage's `env`, never the daemon body's.
+- The render and persist steps became `stages` in declaration order, keeping their original overrides verbatim. `${input.output}` still threads the rendered string from the template stage into the writer.
+- Rotating Doppler secrets is the same as before: re-fire the render stage and the pipeline re-renders and restarts the terminal daemon.
+
+::: tip Full Docker variant
+For an end-to-end Docker variant — a hardened `cloudflared` tunnel whose terminal stage is a Docker daemon — see the [Cloudflare Tunnel worked example](https://github.com/dicode-ayo/dicode-core/blob/main/docs/examples/cloudflare-tunnel.md) in dicode-core.
+:::
+
+## Related
+
+- [Triggers](./triggers.md) — cron / webhook / manual / chain / daemon
+- [Tasks](./tasks.md) — the `kind: Task` reference
+- [Secrets](./secrets.md) — `permissions.env`, secret providers, `run_result.enabled`

--- a/docs-src/concepts/pipelines.md
+++ b/docs-src/concepts/pipelines.md
@@ -2,10 +2,6 @@
 
 A **pipeline** is a `kind: PipelineTask` that declares an ordered list of **stages**. Each stage is an existing `kind: Task`, run as its own child run. A stage must reach `status: success` for the pipeline to advance; the first failure short-circuits the rest. The previous stage's return value is piped forward via `${input.output}`, so the **render → persist → start-daemon** composition lives in one self-contained pipeline definition.
 
-::: info Replaces `trigger.before`
-Pipelines replace the old `trigger.before:` preflight list. Preflight orchestration is no longer a list bolted onto a task — it's a first-class `kind: PipelineTask` whose stages run sequentially before a terminal daemon/body stage. A `task.yaml` that still declares `trigger.before` is **rejected at load**. See [Migrating from `trigger.before`](#migrating-from-trigger-before).
-:::
-
 A pipeline lives in a task folder like any other task — the file is still **`task.yaml`**, discriminated by its `kind:`. There is no separate filename; the loader reads `kind: PipelineTask` and parses the pipeline schema instead of the `kind: Task` schema.
 
 ```yaml
@@ -162,7 +158,7 @@ The dashboard lists runs per task. A pipeline fire shows up as the parent run on
 | Cardinality | One pipeline, N ordered stages | One source, M downstream subscribers (natural fan-out) |
 | Failure semantics | A stage failure short-circuits the pipeline | `on_failure_chain` lets a separate task react to failure |
 
-**Reach for a pipeline** when you own the whole sequence and want it described in one place — especially the render → persist → start-daemon shape that `trigger.before` used to express.
+**Reach for a pipeline** when you own the whole sequence and want it described in one place — especially the render → persist → start-daemon shape.
 
 **Reach for a chain** when:
 
@@ -177,73 +173,12 @@ The dashboard lists runs per task. A pipeline fire shows up as the parent run on
 - **Pipeline → chain:** another task's `trigger.chain.from: <pipeline-id>` fires when the pipeline's **overall** run terminates (not on individual stage completion).
 - **Stage-level `on_failure_chain`** still fires: a stage is a `kind: Task`, so its own configured failure chain fires when that stage fails, independent of the pipeline's short-circuit.
 
-## Migrating from `trigger.before`
+## Worked example: `buildin/relay-server`
 
-`trigger.before` declared a list of preflight steps that ran before a task's daemon/body. The replacement splits that into two pieces:
-
-1. A standalone **daemon-body** `kind: Task` (`trigger.daemon: true`) — the thing that used to host `trigger.before`. It reads its pre-rendered config off disk and is independently runnable.
-2. A **`kind: PipelineTask`** whose render/persist stages run first and whose **terminal stage** is that daemon-body task.
-
-The mechanical conversion:
-
-| Old (`trigger.before`) | New (`kind: PipelineTask`) |
-| --- | --- |
-| The host task with `trigger.daemon: true` | A standalone `kind: Task` daemon body (its own folder) |
-| Each `before[i]` entry | A `stages[i]` entry referencing the same task ID, with the same overrides |
-| `${input.output}` between before-steps | `${input.output}` between stages (unchanged) |
-| The daemon as the implicit "after" step | The daemon body as the **terminal** stage |
-
-### Worked example: `buildin/relay-server`
-
-**Before** — a single daemon task with a `trigger.before` preflight (the shape that is now rejected at load):
+A `kind: PipelineTask` (`task.yaml`) whose terminal stage is a standalone daemon-body `kind: Task`:
 
 ```yaml
-# tasks/buildin/relay-server/task.yaml  (OLD — no longer valid)
-apiVersion: dicode/v1
-kind: Task
-name: Relay Server
-runtime: deno
-
-trigger:
-  daemon: true
-  restart: always
-  before:
-    - task: buildin/template          # render relay.yaml from Doppler-fed env
-      overrides:
-        params:
-          - name: template_path
-            default: "${TASK_DIR}/relay.yaml"
-        fs:
-          - path: "${TASK_DIR}/relay.yaml"
-            permission: r
-        env:
-          - name: BASE_URL
-            value: "https://relay.example.com"
-          # ...Doppler-fed OAuth client_id/secret entries...
-    - task: buildin/write-local       # persist the rendered string
-      overrides:
-        params:
-          - name: content
-            default: "${input.output}"
-          - name: path
-            default: "${DATADIR}/relay/relay.yaml"
-          - name: mode
-            default: "0600"
-        fs:
-          - path: "${DATADIR}/relay"
-            permission: rw
-
-permissions:
-  net: ["*"]
-  fs:
-    - path: "${DATADIR}/relay"
-      permission: rw
-```
-
-**After** — a `kind: PipelineTask` (`task.yaml`) whose terminal stage is a standalone daemon-body `kind: Task`:
-
-```yaml
-# tasks/buildin/relay-server/task.yaml  (NEW — kind: PipelineTask)
+# tasks/buildin/relay-server/task.yaml  (kind: PipelineTask)
 apiVersion: dicode/v1
 kind: PipelineTask
 name: Relay Server
@@ -283,7 +218,7 @@ stages:
 ```
 
 ```yaml
-# tasks/buildin/relay-server-body/task.yaml  (NEW — standalone daemon body)
+# tasks/buildin/relay-server-body/task.yaml  (standalone daemon body)
 apiVersion: dicode/v1
 kind: Task
 name: Relay Server (daemon body)
@@ -304,11 +239,11 @@ permissions:
     - DICODE_VERSION
 ```
 
-What changed and why:
+How this is shaped:
 
-- The daemon body is now a plain `kind: Task` that **reads** the pre-rendered config — it's independently runnable and carries no rendering concern. OAuth secrets and the status password are scoped to the render stage's `env`, never the daemon body's.
-- The render and persist steps became `stages` in declaration order, keeping their original overrides verbatim. `${input.output}` still threads the rendered string from the template stage into the writer.
-- Rotating Doppler secrets is the same as before: re-fire the render stage and the pipeline re-renders and restarts the terminal daemon.
+- The daemon body is a plain `kind: Task` that **reads** the pre-rendered config — it's independently runnable and carries no rendering concern. OAuth secrets and the status password are scoped to the render stage's `env`, never the daemon body's.
+- The render and persist steps are `stages` in declaration order. `${input.output}` threads the rendered string from the template stage into the writer.
+- Rotating Doppler secrets is simple: re-fire the render stage and the pipeline re-renders and restarts the terminal daemon.
 
 ::: tip Full Docker variant
 For an end-to-end Docker variant — a hardened `cloudflared` tunnel whose terminal stage is a Docker daemon — see the [Cloudflare Tunnel worked example](https://github.com/dicode-ayo/dicode-core/blob/main/docs/examples/cloudflare-tunnel.md) in dicode-core.

--- a/docs-src/concepts/pipelines.md
+++ b/docs-src/concepts/pipelines.md
@@ -74,14 +74,14 @@ A pipeline accepts `manual`, `cron`, `webhook` (with optional `webhook_secret` /
 
 ## Stage input threading
 
-Stages share the same `${input.…}` interpolation grammar as [chain params](./triggers.md#chain), evaluated at dispatch time against the **previous stage's** output:
+Stages thread data forward with the `${input.…}` interpolation grammar below, evaluated at dispatch time against the **previous stage's** output. (This is the dispatch-time token grammar; it is distinct from the runtime [`input` global](./triggers.md#input-passing) that a chained task reads.)
 
 | Form | Resolves to |
 | --- | --- |
 | `${input.output}` | the previous stage's full string return value |
 | `${input.output.<field>}` | a named string field of an object-shaped previous-stage return (e.g. `{path: "..."}`) |
 
-These tokens are used inside `stages[].overrides.params` defaults (and the other override string fields). Empty strings are treated as "not provided": a token that would resolve to an empty string **fails the stage loudly** (`ErrInputUnavailable`) rather than substituting silently. Embedded forms (`"prefix-${input.output}-suffix"`) and multi-token forms work too. The `<field>` portion accepts letters, digits, underscores, hyphens, and dots — so `${input.output.db.host}` works without escapes.
+These tokens are resolved **only** inside `stages[].overrides.params` defaults. Other override fields (`env[].value`, `fs[].path`, `timeout`, ...) are applied verbatim -- a `${input.…}` token in those is **not** interpolated and would be passed through literally. Empty strings are treated as "not provided": a token that would resolve to an empty string **fails the stage loudly** (`ErrInputUnavailable`) rather than substituting silently. Embedded forms (`"prefix-${input.output}-suffix"`) and multi-token forms work too. The `<field>` portion accepts letters, digits, underscores, hyphens, and dots — so `${input.output.db.host}` works without escapes.
 
 ::: warning v1 threads `Output` only
 `${input.params.<name>}` (referencing the *upstream stage's* input params) is **not** supported in sequential pipelines and is rejected at load on every stage. Cross-stage param threading is a planned follow-up; for now, thread data forward through each stage's **return value** (`${input.output}`).

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -174,7 +174,7 @@ Exactly one trigger type must be configured per task.
 | **Chain** | `chain: { from: task-id, on: success }` | Fires after another task completes |
 | **Daemon** | `daemon: true` | Long-running process, started with the service |
 
-To run an ordered sequence of stages before a daemon or body — render a config, persist it, then start the daemon — use a **`kind: PipelineTask`** instead of a trigger field. (The old `trigger.before:` preflight list has been removed and is rejected at load.) See [Pipelines](./pipelines.md).
+To run an ordered sequence of stages before a daemon or body — render a config, persist it, then start the daemon — use a **`kind: PipelineTask`** instead of a trigger field. See [Pipelines](./pipelines.md).
 
 ### Enable / disable
 

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -174,7 +174,7 @@ Exactly one trigger type must be configured per task.
 | **Chain** | `chain: { from: task-id, on: success }` | Fires after another task completes |
 | **Daemon** | `daemon: true` | Long-running process, started with the service |
 
-Any trigger type can also declare a `trigger.before:` **preflight pipeline** — a sequential list of one-shot prereq tasks that must succeed before the main body runs. See [Triggers → Preflight pipelines](./triggers.md#preflight-pipelines).
+To run an ordered sequence of stages before a daemon or body — render a config, persist it, then start the daemon — use a **`kind: PipelineTask`** instead of a trigger field. (The old `trigger.before:` preflight list has been removed and is rejected at load.) See [Pipelines](./pipelines.md).
 
 ### Enable / disable
 

--- a/docs-src/concepts/triggers.md
+++ b/docs-src/concepts/triggers.md
@@ -318,22 +318,18 @@ Daemons cycle through a small set of states observable in the dashboard and via 
 | `failed_after_preflight` | The daemon body's **launch** errored (binary missing, port already bound, runtime resource exhaustion -- `fireAsync` returned an error before the body ran). Terminal -- re-fire the daemon to retry. |
 | `crashed` | The body started, then exited non-success (`failure`, `cancelled`, ...) **and** the restart policy will not restart it (`restart: never`, or `restart: on-failure` with a status not treated as a failure). Terminal -- re-fire the daemon to retry. |
 
-The `failed_after_preflight` name is historical: pre-`PipelineTask` it meant "preflight passed but body launch failed". Daemons no longer preflight, so it now simply means "body launch failed" -- the string is kept so existing dashboards and API consumers don't break.
+`failed_after_preflight` means "body launch failed" -- the daemon body's launch errored before the body ran.
 
 A run that backs a daemon reports one of the standard run statuses — `running`, `success`, `failure`, or `cancelled`. These are a **separate** enum from the daemon states above (there is no `crashed` run status, for example). A daemon killed before it exits (operator kill or engine shutdown) records `cancelled`.
 
 ::: tip Need a render → persist → start-daemon flow?
-If your daemon needs config rendered and written to disk before it boots, model that as a [pipeline](./pipelines.md): a `kind: PipelineTask` whose render/persist stages run first and whose **terminal stage** is the daemon `kind: Task`. This replaces the old `trigger.before` preflight list.
+If your daemon needs config rendered and written to disk before it boots, model that as a [pipeline](./pipelines.md): a `kind: PipelineTask` whose render/persist stages run first and whose **terminal stage** is the daemon `kind: Task`.
 :::
 
 ---
 
 ## Pipelines (render → persist → start-daemon)
 
-::: info `trigger.before` was removed
-Earlier versions let any trigger declare a `trigger.before:` list of preflight prereq tasks. That has been **removed** — a `task.yaml` that still declares `trigger.before` is rejected at load. Preflight orchestration is now a first-class `kind: PipelineTask`.
-:::
-
 To run an ordered sequence of stages before a daemon or body — render a config, persist it to disk, then start the daemon — declare a **`kind: PipelineTask`**. Each stage is an existing `kind: Task`; stages run sequentially, each stage's return value threads to the next via `${input.output}`, and the first failure short-circuits the rest. When the **terminal stage** is a daemon, the pipeline stays `running` for the daemon's lifetime.
 
-See [Pipelines](./pipelines.md) for the full reference, including the [`trigger.before` → `kind: PipelineTask` migration guide](./pipelines.md#migrating-from-trigger-before).
+See [Pipelines](./pipelines.md) for the full reference.

--- a/docs-src/concepts/triggers.md
+++ b/docs-src/concepts/triggers.md
@@ -312,12 +312,15 @@ Daemons cycle through a small set of states observable in the dashboard and via 
 
 | State | Meaning |
 | --- | --- |
-| `stopped` | Resting state (clean exit). Either deliberately stopped, never started, or ran to completion with `status: success` and no restart configured. |
-| `running` | The daemon body is executing. |
-| `stopping` | The engine is shutting the daemon down (operator unregister or engine shutdown). |
-| `failed` | The daemon's body ran but exited non-success and the restart policy isn't going to restart it. Distinct from `stopped` so clean exits and failures are visibly different. Terminal — re-fire the daemon to retry. |
+| `stopped` | Resting state. Either deliberately stopped, never started, or the body exited cleanly (`status: success`) with no restart configured. |
+| `running` | The daemon body launched successfully and is up. |
+| `stopping` | A restart is in flight -- the engine is tearing down the current run before re-firing the daemon. |
+| `failed_after_preflight` | The daemon body's **launch** errored (binary missing, port already bound, runtime resource exhaustion -- `fireAsync` returned an error before the body ran). Terminal -- re-fire the daemon to retry. |
+| `crashed` | The body started, then exited non-success (`failure`, `cancelled`, ...) **and** the restart policy will not restart it (`restart: never`, or `restart: on-failure` with a status not treated as a failure). Terminal -- re-fire the daemon to retry. |
 
-A run that backs a daemon reports one of the standard run statuses — `running`, `success`, `failure`, or `cancelled`. A daemon killed before it exits (operator kill or engine shutdown) records `cancelled`.
+The `failed_after_preflight` name is historical: pre-`PipelineTask` it meant "preflight passed but body launch failed". Daemons no longer preflight, so it now simply means "body launch failed" -- the string is kept so existing dashboards and API consumers don't break.
+
+A run that backs a daemon reports one of the standard run statuses — `running`, `success`, `failure`, or `cancelled`. These are a **separate** enum from the daemon states above (there is no `crashed` run status, for example). A daemon killed before it exits (operator kill or engine shutdown) records `cancelled`.
 
 ::: tip Need a render → persist → start-daemon flow?
 If your daemon needs config rendered and written to disk before it boots, model that as a [pipeline](./pipelines.md): a `kind: PipelineTask` whose render/persist stages run first and whose **terminal stage** is the daemon `kind: Task`. This replaces the old `trigger.before` preflight list.

--- a/docs-src/concepts/triggers.md
+++ b/docs-src/concepts/triggers.md
@@ -313,87 +313,24 @@ Daemons cycle through a small set of states observable in the dashboard and via 
 | State | Meaning |
 | --- | --- |
 | `stopped` | Resting state (clean exit). Either deliberately stopped, never started, or ran to completion with `status: success` and no restart configured. |
-| `prereq_running` | The `trigger.before` preflight pipeline is executing. |
-| `prereq_failed` | A preflight stage returned a non-success status. The daemon will not start until the failing stage is re-fired successfully. |
 | `running` | The daemon body is executing. |
 | `stopping` | The engine is shutting the daemon down (operator unregister or engine shutdown). |
-| `failed_after_preflight` | Preflight succeeded, but the daemon's own dispatch errored (binary missing, port already bound, etc.). Terminal — re-fire the daemon to retry. |
-| `crashed` | The daemon's body ran but exited non-success and the restart policy isn't going to restart it. Distinct from `stopped` so clean exits and crashes are visibly different. Terminal — re-fire the daemon to retry. |
+| `failed` | The daemon's body ran but exited non-success and the restart policy isn't going to restart it. Distinct from `stopped` so clean exits and failures are visibly different. Terminal — re-fire the daemon to retry. |
+
+A run that backs a daemon reports one of the standard run statuses — `running`, `success`, `failure`, or `cancelled`. A daemon killed before it exits (operator kill or engine shutdown) records `cancelled`.
+
+::: tip Need a render → persist → start-daemon flow?
+If your daemon needs config rendered and written to disk before it boots, model that as a [pipeline](./pipelines.md): a `kind: PipelineTask` whose render/persist stages run first and whose **terminal stage** is the daemon `kind: Task`. This replaces the old `trigger.before` preflight list.
+:::
 
 ---
 
-## Preflight pipelines
+## Pipelines (render → persist → start-daemon)
 
-Any trigger type — daemon, manual, cron, webhook, or chain — can declare a `trigger.before:` pipeline of one-shot prereq tasks that must succeed before the main task body runs. Stages run **sequentially in declaration order**, and each stage's return value is piped to the next via `${input.output}`. If any stage fails, the pipeline short-circuits and the main body does not run.
+::: info `trigger.before` was removed
+Earlier versions let any trigger declare a `trigger.before:` list of preflight prereq tasks. That has been **removed** — a `task.yaml` that still declares `trigger.before` is rejected at load. Preflight orchestration is now a first-class `kind: PipelineTask`.
+:::
 
-```yaml
-trigger:
-  daemon: true
-  restart: always
-  before:
-    # Stage 1: render config from secrets + literal values.
-    - task: buildin/template
-      overrides:
-        params:
-          template: |
-            base_url: ${BASE_URL}
-            password: ${STATUS_PASSWORD}
-        env:
-          - name: BASE_URL
-            value: "https://relay.example.com"
-          - name: STATUS_PASSWORD
-            from: task:secret-providers/doppler
+To run an ordered sequence of stages before a daemon or body — render a config, persist it to disk, then start the daemon — declare a **`kind: PipelineTask`**. Each stage is an existing `kind: Task`; stages run sequentially, each stage's return value threads to the next via `${input.output}`, and the first failure short-circuits the rest. When the **terminal stage** is a daemon, the pipeline stays `running` for the daemon's lifetime.
 
-    # Stage 2: persist stage 1's rendered output to disk.
-    - task: buildin/write-local
-      overrides:
-        params:
-          content: "${input.output}"
-          path: "${DATADIR}/relay/relay.yaml"
-          mode: "0600"
-        fs:
-          - path: "${DATADIR}/relay"
-            permission: rw
-```
-
-Each `before[]` entry can be a bare task-ID string or a `{task, overrides}` mapping. Per-edge overrides accept the same conservative subset as `trigger.chain.overrides` (`params`, `env`, `net`, `fs`, `timeout`, `dicode`, `runtime` — not `trigger`, `enabled`, `name`, etc.). Forms can be mixed within the same list.
-
-The engine re-fires every stage on every preflight attempt — there's no "already-satisfied" short-circuit — because the point of preflight is to refresh ephemeral state (rendered configs, freshly rotated credentials) right before the body runs.
-
-**Run-row semantics on failure:**
-
-- **Daemon** — preflight failure leaves the daemon in `prereq_failed` and no daemon-body run is created.
-- **One-shot** (manual / cron / webhook / chain) — preflight + body collapse into a single parent run row. Preflight failure surfaces as `status=failure` with `fail_reason="preflight_failed: stage N (<task-id>): <error>"`.
-
-Preflight stages run as their own child runs tagged `trigger_source=preflight`, linked back to the parent fire — the dashboard groups them under the parent for visibility.
-
-### `${input.output}` interpolation
-
-Three reference shapes are recognised at dispatch time in `before[i].overrides.params` defaults and `trigger.chain.params` values:
-
-| Form | Resolves to |
-| --- | --- |
-| `${input.output}` | upstream's full string return value |
-| `${input.output.<field>}` | named string field of an object-shaped upstream return (e.g. `{path: "..."}`) |
-| `${input.params.<name>}` | named entry from the upstream's `RunOptions.Params` (chain edge only — preflight edges run with empty params) |
-
-Embedded forms (`"prefix-${input.output}-suffix"`) and multi-token forms (`"${input.params.scheme}://${input.output.host}"`) work too — any string containing one or more recognised tokens is rewritten in place. The `<field>` / `<name>` portion accepts letters, digits, underscores, hyphens, and dots, so common shapes like `${input.params.x-forwarded-for}` and `${input.output.db.host}` work without escapes.
-
-References that can't be resolved at dispatch time fail loud — the chain or preflight dispatch is skipped rather than passing a literal token to the downstream. Unknown shapes (e.g. `${input.foo}`) are rejected at task-registration time with a site-qualified error so misuse surfaces at config-load.
-
-The first stage (`before[0]`) has no upstream return value, so any `${input.…}` reference there is rejected at registration. Use a literal default or an env-projected secret on stage 0; downstream stages can then pipe via `${input.output}`.
-
-### Mid-pipeline re-fire (daemon-only)
-
-When an intermediate stage at index `i` re-runs successfully — e.g. an operator manually fires `buildin/template` to pick up a rotated secret — the engine re-fires stages `[i+1..n-1]` with the re-run's fresh return value as the initial `${input.output}`, then restarts the daemon to pick up the propagated config. Propagations are coalesced per daemon (at most one in flight) so a flurry of upstream completions produces a single re-render + restart, not a thrash loop. One-shots don't auto-restart on a prereq re-run — re-fire the one-shot yourself if you want it to re-run.
-
-### Registration-time validation
-
-The engine rejects at registration:
-
-- References to unknown tasks.
-- References to daemons (only one-shot tasks can be preflights).
-- Self-references and cycles in the before-graph (e.g. `A.before: [B]; B.before: [A]`).
-- `${input.params.<name>}` on any `before[]` edge — preflight stages run with empty `RunOptions`, so the upstream params channel is statically unavailable.
-
-For an end-to-end example combining daemon preflight, per-edge overrides, `${DATADIR}` volumes, and secret rotation, see the [Cloudflare Tunnel worked example](https://github.com/dicode-ayo/dicode-core/blob/main/docs/examples/cloudflare-tunnel.md) in dicode-core.
+See [Pipelines](./pipelines.md) for the full reference, including the [`trigger.before` → `kind: PipelineTask` migration guide](./pipelines.md#migrating-from-trigger-before).


### PR DESCRIPTION
## Summary

Syncs the dicode-site docs to the dicode-core **`kind: PipelineTask`** epic (core PRs **#339–#347** merged — **#347** is the hard cut of `trigger.before`; core docs land in **#349**). The site now documents `kind: PipelineTask` as the single, first-class way to express render → persist → start-daemon flows.

> **Clean-slate update (2026-05-25):** All legacy `trigger.before` content has been removed from this PR. Per a clean-slate decision, the site documents **only** `kind: PipelineTask` — there is no migration guide and no "removed"/"was removed" notices; the old mechanism is not mentioned at all. The `buildin/relay-server` example remains as a plain `kind: PipelineTask` worked example, and the 5-value daemon-state enum (`stopped`, `running`, `stopping`, `failed_after_preflight`, `crashed`) is retained with the preflight-era framing stripped.

## Docs changes

- **`docs-src/concepts/pipelines.md`** — full `kind: PipelineTask` reference mirroring the core docs, adapted to the site's VitePress voice:
  - schema / fields table, `subtype: sequential` (v1 only)
  - sequential semantics + 0-based `stage N` short-circuit
  - `${input.output}` / `${input.output.<field>}` stage threading; cross-stage `${input.params.*}` rejected in v1; stage 0 receives no input
  - stage `overrides` (wider allowlist than chain edges — may override `trigger` to flip daemon-ness)
  - daemon terminal stage + re-rendering a live daemon
  - status semantics and the N+1 parent/child run shape
  - pipeline-vs-chain guidance
  - the `buildin/relay-server` worked example, presented purely as a PipelineTask
- **Registered** the **Pipelines** page in the VitePress sidebar (`docs-src/.vitepress/config.ts`).
- **`triggers.md`** — Pipelines section presents `kind: PipelineTask` cleanly with a plain "see Pipelines" cross-reference; daemon-states table uses the shipped 5-value enum with no preflight-era framing.
- **`tasks.md`** — points to the Pipelines page with no reference to the old mechanism.

## Built output

The committed `docs/` build output is **gitignored**, so no regenerated HTML is committed. `vitepress build docs-src` passes with VitePress's dead-internal-link check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
