### PR TITLE
docs: webhook replay protection

### DIFF
--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -69,6 +69,7 @@ trigger:
   cron: "0 9 * * *"              # 5-field cron expression
   webhook: /hooks/my-task        # HTTP path
   webhook_secret: "${SECRET}"    # HMAC-SHA256 secret (env var interpolation)
+  replay_protection: false       # nonce-cache replay guard (default true when secret set)
   auth: true                     # require dicode session — see /concepts/triggers#session-authentication
   manual: true                   # only triggered explicitly
   daemon: true                   # long-running process

--- a/docs-src/concepts/triggers.md
+++ b/docs-src/concepts/triggers.md
@@ -58,6 +58,23 @@ The secret value supports `${ENV_VAR}` interpolation -- the actual secret is rea
 You never need to verify the HMAC signature in your task script. dicode handles this automatically when `webhook_secret` is configured.
 :::
 
+### Replay protection
+
+When `webhook_secret` is set, dicode automatically rejects duplicate webhook bodies within a 1-hour window. This prevents replay attacks -- the task fires once and subsequent identical requests return HTTP 409 Conflict.
+
+The nonce cache is keyed on the HMAC digest (already computed during signature verification), bounded to 10,000 entries, and kept in memory. It works for both `kind: Task` and `kind: PipelineTask` webhooks.
+
+Replay protection is enabled by default. Opt out per task if your sender legitimately sends byte-identical payloads:
+
+```yaml
+trigger:
+  webhook: /hooks/idempotent-task
+  webhook_secret: "${SECRET}"
+  replay_protection: false
+```
+
+Open webhooks (no `webhook_secret`) are unaffected -- replay protection only applies when signature verification is active.
+
 ### Session authentication
 
 For webhooks that should only be accessible to authenticated dicode users (not external services):


### PR DESCRIPTION
## Summary

- Document the new webhook replay protection feature (dicode-core PR #358)
- Added replay protection subsection to `docs-src/concepts/triggers.md` under HMAC authentication
- Added `replay_protection` field to task.yaml reference in `docs-src/concepts/tasks.md`

Companion to dicode-ayo/dicode-core#358

🤖 Generated with [Claude Code](https://claude.ai/code)