### PR TITLE
docs: update MCP, pipeline, and task docs for new features

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -95,10 +95,11 @@ jobs:
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           # steps.slug.outputs.safe is constrained to [a-z0-9-] by the
           # sanitize step above, so interpolation here is safe by construction.
           command: pages deploy docs --project-name=dicode-site --branch=${{ steps.slug.outputs.safe }} --commit-dirty=true
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Comment preview URL on PR
         # Sticky comment that updates in place on every push instead of spamming.

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -95,6 +95,7 @@ jobs:
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           # steps.slug.outputs.safe is constrained to [a-z0-9-] by the
           # sanitize step above, so interpolation here is safe by construction.
           command: pages deploy docs --project-name=dicode-site --branch=${{ steps.slug.outputs.safe }} --commit-dirty=true

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -67,6 +67,7 @@ jobs:
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           # --branch=main makes this the production deployment for the
           # dicode-site project. Without --branch it would deploy as a
           # preview at a per-commit URL only.

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -67,8 +67,9 @@ jobs:
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           # --branch=main makes this the production deployment for the
           # dicode-site project. Without --branch it would deploy as a
           # preview at a per-commit URL only.
           command: pages deploy docs --project-name=dicode-site --branch=main --commit-dirty=true
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/docs-src/concepts/mcp-server.md
+++ b/docs-src/concepts/mcp-server.md
@@ -32,12 +32,16 @@ The MCP server exposes six tools. Three are direct passthroughs to the dicode SD
 
 | Tool | What it does | Backed by |
 |---|---|---|
-| `list_tasks` | Returns all registered tasks with their IDs, names, descriptions, and declared params. | `dicode.list_tasks()` |
-| `get_task` | Returns the spec for a single task. | `dicode.list_tasks()` filtered by id |
-| `run_task` | Triggers a task by ID and waits for it to finish. Returns the run result. | `dicode.run_task()` |
+| `list_tasks` | Returns MCP-exposed tasks with their IDs, names, descriptions, and declared params. Only tasks with `mcp_exposed: true` in their `task.yaml` appear — all others are hidden from MCP by default. | `dicode.list_tasks()` |
+| `get_task` | Returns the spec for a single task. The task must have `mcp_exposed: true`; querying a non-exposed task returns an error. | `dicode.list_tasks()` filtered by id |
+| `run_task` | Triggers a task by ID and waits for it to finish. Returns the run result. The task must have `mcp_exposed: true`; invoking a non-exposed task returns an error. | `dicode.run_task()` |
 | `list_sources` | Hint: call `GET /api/sources` directly. | — |
 | `switch_dev_mode` | Hint: call `PATCH /api/sources/{name}/dev` directly. | — |
 | `test_task` | Hint: call `POST /api/tasks/{id}/test` directly. | — |
+
+::: warning Tasks must opt in to MCP exposure
+By default, tasks are **hidden** from MCP clients. To make a task visible to `list_tasks` and invokable via `tools/call`, set `mcp_exposed: true` in its `task.yaml`. This prevents unintended exposure of internal tasks to MCP clients. Calling `get_task` or `run_task` on a non-exposed task returns a JSON-RPC error. See [Tasks — `mcp_exposed`](./tasks.md#field-reference) for the field reference.
+:::
 
 The "hint" tools intentionally don't proxy. Every MCP client already has the dicode API key (it's how it reached `/mcp`), so when it needs to manage sources or run task tests, it calls the corresponding REST endpoint directly with the same key — one less round-trip than going through MCP.
 

--- a/docs-src/concepts/pipelines.md
+++ b/docs-src/concepts/pipelines.md
@@ -41,7 +41,7 @@ stages:
 | `kind` | string | yes | Must be `PipelineTask` |
 | `name` | string | yes | Human-readable pipeline name |
 | `description` | string | no | One-line (or multi-line) description |
-| `subtype` | string | yes | Must be `sequential` in v1. Any other value (e.g. `parallel`) is rejected at load — parallel pipelines are a planned follow-up. |
+| `subtype` | string | yes | `sequential` or `parallel`. See [Sequential semantics](#sequential-semantics) and [Parallel semantics](#parallel-semantics). |
 | `trigger` | object | no | How the **pipeline** is fired. At most one trigger type. Omit for a pipeline that's only fired programmatically (e.g. via `dicode.run_task`). |
 | `trigger.manual` | bool | no | Manual-only fire (API / UI) |
 | `trigger.cron` | string | no | Standard 5-field cron expression |
@@ -51,6 +51,8 @@ stages:
 | `trigger.chain` | object | no | Chain trigger — fire the pipeline when an upstream task/pipeline completes |
 | `stages` | list | yes | Ordered list of stages; at least one required |
 | `stages[].task` | string | yes | Task ID of an existing `kind: Task` to run as this stage |
+| `stages[].id` | string | no | Stable identifier for the stage, used as a `depends_on` target in parallel pipelines. Defaults to the stage's `task` value. |
+| `stages[].depends_on` | list of strings | no | Stage IDs this stage waits for before starting (`subtype: parallel` only). Omit for stages with no dependencies — they start immediately. |
 | `stages[].overrides` | object | no | Per-stage patch applied to the stage task's spec at dispatch time (see [Stage overrides](#stage-overrides)) |
 | `timeout` | duration | no | Overall pipeline timeout (e.g. `5m`). Cancels the in-flight stage and fails the pipeline if exceeded. |
 
@@ -67,6 +69,41 @@ A pipeline accepts `manual`, `cron`, `webhook` (with optional `webhook_secret` /
 1. Each non-terminal stage is fired as a child run and the pipeline **waits for it to reach `success`** before advancing.
 2. The stage's return value is threaded into the next stage as `${input.output}` (see [Stage input threading](#stage-input-threading)).
 3. The first stage to reach `failure` / `timeout` / `cancelled` **short-circuits** the pipeline: the remaining stages are never fired, the pipeline's run goes to `failure`, and `fail_reason` is set to `stage N (<task-id>): <error>` (N is **0-based**, so the first stage failing reports `stage 0 (...)`).
+
+## Parallel semantics
+
+`subtype: parallel` runs stages as a DAG, governed by `depends_on`:
+
+1. Stages with **no `depends_on`** start immediately and run concurrently.
+2. A stage with `depends_on: [A, B]` waits for **all** listed stages to reach `success` before starting (fan-in).
+3. **Fail-fast**: the first stage failure cancels all in-flight sibling stages. The pipeline's run goes to `failure` with `fail_reason` identifying the failed stage.
+4. The pipeline succeeds only when **every** stage reaches `success`.
+
+```yaml
+apiVersion: dicode/v1
+kind: PipelineTask
+name: Build and deploy
+description: Lint and test in parallel, then deploy.
+subtype: parallel
+
+trigger:
+  manual: true
+
+stages:
+  - id: lint
+    task: ci/lint
+  - id: test
+    task: ci/test
+  - id: deploy
+    task: ci/deploy
+    depends_on: [lint, test]   # waits for both to succeed
+```
+
+In this example `lint` and `test` start concurrently. `deploy` starts only after both succeed. If either fails, the other is cancelled and `deploy` never fires.
+
+::: warning No input threading in parallel pipelines
+`${input.output}` is available only in `subtype: sequential` pipelines. In parallel pipelines, stages communicate through shared state (KV, filesystem) or params — not through the `${input.…}` grammar.
+:::
 
 ## Stage input threading
 

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -69,6 +69,7 @@ trigger:
   cron: "0 9 * * *"              # 5-field cron expression
   webhook: /hooks/my-task        # HTTP path
   webhook_secret: "${SECRET}"    # HMAC-SHA256 secret (env var interpolation)
+  replay_protection: false       # nonce-cache replay guard (default true when secret set)
   auth: true                     # require dicode session — see /concepts/triggers#session-authentication
   manual: true                   # only triggered explicitly
   daemon: true                   # long-running process

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -131,6 +131,7 @@ docker:                          # docker/podman runtime only
   pull_policy: missing           # always | missing | never
 
 timeout: 30s                     # default 60s for script tasks; no default for docker/daemon
+mcp_exposed: true                # visible to MCP clients via list_tasks / tools/call
 mcp_port: 3000                   # daemon exposes MCP server on this port
 on_failure_chain: buildin/alert  # short form — task to run on failure
 # or the structured form:
@@ -160,6 +161,7 @@ on_failure_chain: buildin/alert  # short form — task to run on failure
 | `permissions` | object | no | Security sandbox declarations |
 | `docker` | object | conditional | Required when runtime is `docker` or `podman` |
 | `timeout` | duration | no | Max execution time (default `60s` for scripts) |
+| `mcp_exposed` | bool | no | Default `false`. When `true`, the task is visible to MCP clients via `list_tasks` and can be invoked via `tools/call`. When `false` (default), the task is hidden from MCP. See [MCP Server](./mcp-server.md). |
 | `mcp_port` | int | no | Port where a daemon task exposes an MCP server |
 | `on_failure_chain` | string \| object | no | Task ID (short form) or structured block to trigger on failure. Used for notifications, auto-fix, and any other side-effect chain. See [Auto-fix loop](./auto-fix.md). |
 

--- a/docs-src/concepts/triggers.md
+++ b/docs-src/concepts/triggers.md
@@ -58,6 +58,23 @@ The secret value supports `${ENV_VAR}` interpolation -- the actual secret is rea
 You never need to verify the HMAC signature in your task script. dicode handles this automatically when `webhook_secret` is configured.
 :::
 
+### Replay protection
+
+When `webhook_secret` is set, dicode automatically rejects duplicate webhook bodies within a 1-hour window. This prevents replay attacks -- the task fires once and subsequent identical requests return HTTP 409 Conflict.
+
+The nonce cache is keyed on the HMAC digest (already computed during signature verification), bounded to 10,000 entries, and kept in memory. It works for both `kind: Task` and `kind: PipelineTask` webhooks.
+
+Replay protection is enabled by default. Opt out per task if your sender legitimately sends byte-identical payloads:
+
+```yaml
+trigger:
+  webhook: /hooks/idempotent-task
+  webhook_secret: "${SECRET}"
+  replay_protection: false
+```
+
+Open webhooks (no `webhook_secret`) are unaffected -- replay protection only applies when signature verification is active.
+
 ### Session authentication
 
 For webhooks that should only be accessible to authenticated dicode users (not external services):


### PR DESCRIPTION
## Summary
- Document `mcp_exposed` opt-in filter for MCP tool surface (dicode-ayo/dicode-core#366)
- Document `subtype: parallel` with `depends_on` DAG ordering (dicode-ayo/dicode-core#368)
- Add `mcp_exposed` field to task.yaml reference

## Files changed
- `docs-src/concepts/mcp-server.md` — tool surface table + warning callout
- `docs-src/concepts/pipelines.md` — parallel semantics section + example
- `docs-src/concepts/tasks.md` — field reference + YAML example

🤖 Generated with [Claude Code](https://claude.com/claude-code)