### PR TITLE
docs: document container security floor for Docker/Podman tasks

### DIFF
--- a/docs-src/concepts/runtimes.md
+++ b/docs-src/concepts/runtimes.md
@@ -171,6 +171,7 @@ Run tasks in any Docker container. Supports any language, any toolchain.
 - **Live logs**: Container stdout/stderr is streamed to the run log in real time.
 - **Kill support**: Long-running containers can be stopped from the UI or CLI.
 - **Orphan cleanup**: dicode tracks all containers it starts and cleans up orphans on restart.
+- **Security floor**: Certain host-facing options (`network_mode: host`, dangerous `cap_add`, insecure `security_opt`, sensitive bind mounts) are rejected by default. See [Container Security](/getting-started/configuration#container-security) for details and opt-in configuration.
 
 ### Task structure
 
@@ -257,6 +258,7 @@ A rootless, daemonless alternative to Docker. Uses the same `docker:` config blo
 - **Rootless**: Runs containers without root privileges.
 - **Same config**: Uses the identical `docker:` block in task.yaml -- just change `runtime: podman`.
 - **Drop-in replacement**: If you can run it with Docker, you can run it with Podman.
+- **Security floor**: Certain host-facing options (`network_mode: host`, dangerous `cap_add`, insecure `security_opt`, sensitive bind mounts) are rejected by default. See [Container Security](/getting-started/configuration#container-security) for details and opt-in configuration.
 
 ```yaml
 apiVersion: dicode/v1

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -238,6 +238,12 @@ Required when `runtime` is `docker` or `podman`. Must specify either `image` or 
 | `env_vars` | Extra environment variables (literal values) |
 | `pull_policy` | `always`, `missing` (default), or `never` |
 
+::: warning Container security floor
+By default, dicode rejects Docker and Podman task configurations that use host networking, dangerous Linux capabilities, insecure `security_opt` values, or bind mounts to sensitive system paths. Tasks with such configuration will fail at start time with a descriptive error.
+
+To opt in to a specific exception, add a `container_security:` block to `dicode.yaml` — see [Container Security](/getting-started/configuration#container-security). Named and anonymous volumes (not host bind-mounts) are always allowed.
+:::
+
 ## Return values
 
 Tasks can return structured data that is stored with the run result and passed as `input` to chained tasks.

--- a/docs-src/getting-started/configuration.md
+++ b/docs-src/getting-started/configuration.md
@@ -285,6 +285,35 @@ Available runtimes:
 | `docker` | _(none -- uses image)_ | N/A |
 | `podman` | _(none -- uses image)_ | N/A |
 
+## Container Security
+
+Docker and Podman tasks are subject to a **container security floor**: dangerous host configuration is rejected at run time before the container is created. You can selectively opt in to specific exceptions via `container_security:` in `dicode.yaml`.
+
+```yaml
+container_security:
+  allow_host_network: false          # allow network_mode: host (default: false)
+  allow_insecure_security_opt: false # allow seccomp=unconfined / apparmor=unconfined (default: false)
+  allowed_cap_add: []                # cap_add values the operator permits, e.g. ["NET_BIND_SERVICE"]
+  allowed_volume_roots: []           # additional host paths allowed as bind-mount sources
+```
+
+**Rejected by default:**
+- `network_mode: host` / `container:` / `ns:`
+- Dangerous capabilities: `ALL`, `SYS_ADMIN`, `SYS_PTRACE`, `SYS_MODULE`, `SYS_RAWIO`, `SYS_BOOT`, `SYS_TIME`, `NET_ADMIN`, `DAC_READ_SEARCH`, `DAC_OVERRIDE`, `BPF`, `SYSLOG`
+- `security_opt`: `seccomp=unconfined`, `apparmor=unconfined`, `label=disable`, `systempaths=unconfined`
+- Bind mounts resolving to sensitive system paths (`/proc`, `/sys`, `/etc`, `/dev`, `/boot`, `/root`, `/run`, `/var/run`, `/var/lib/docker`, `/var/lib/containers`) or Docker/Podman sockets
+
+A task that uses one of these configurations will have its run aborted with a descriptive error. To allow it, add the corresponding opt-in to `container_security` in your `dicode.yaml`.
+
+**Example: allow host networking for a task that legitimately requires it:**
+
+```yaml
+container_security:
+  allow_host_network: true
+```
+
+Named and anonymous volumes (not host bind-mounts) are always allowed.
+
 ## Config variables
 
 Path fields in `dicode.yaml` support these template variables:


### PR DESCRIPTION
## Summary

Closes #65. Documents the enforced container security floor introduced in dicode-core PR #397 (which closes dicode-core#380). Before that PR, dangerous Docker/Podman host configuration produced warnings; it now aborts the run with a descriptive error. Operators must explicitly opt in via `container_security.*` in `dicode.yaml`.

## Files changed

- `docs-src/getting-started/configuration.md` — new `## Container Security` section documenting all 4 opt-in fields (`allow_host_network`, `allow_insecure_security_opt`, `allowed_cap_add`, `allowed_volume_roots`), the full rejected-by-default list, and a YAML example for host networking opt-in
- `docs-src/concepts/tasks.md` — VitePress `::: warning` callout in the Docker runtime config table section pointing to the security floor and the configuration reference
- `docs-src/concepts/runtimes.md` — security floor bullet added to both the Docker and Podman intro bullet lists, linking to the configuration reference

## Test plan

- [x] `npm run build` completes with no errors or broken links
- [ ] Review `## Container Security` section in configuration.md for accuracy against dicode-core#397
- [ ] Confirm warning callout renders correctly in VitePress preview

---
_Generated by [Claude Code](https://claude.ai/code/session_01GW3FUuKwmARGvkYnR4N4hJ)_