### PR TITLE
docs(relay): note that relay-server-body only starts when relay is configured

### DIFF
--- a/docs-src/concepts/relay.md
+++ b/docs-src/concepts/relay.md
@@ -42,6 +42,10 @@ relay:
 
 That is all. On next startup, the daemon connects to the relay and logs the assigned public URL.
 
+::: info How relay startup works
+The relay connection is managed by an internal daemon task (`buildin/relay-server-body`). It is automatically **disabled** at registration unless **both** `relay.enabled: true` and `relay.server_url` are set — if either is missing, the task never starts and produces no log output. Once you add both values, the reconciler picks them up within ~30 seconds; no daemon restart is needed.
+:::
+
 ---
 
 ## Identity


### PR DESCRIPTION
## Summary

Adds an info callout to the relay Setup section explaining that the `buildin/relay-server-body` daemon task is automatically disabled unless **both** `relay.enabled: true` and `relay.server_url` are set.

This was a genuine documentation gap surfaced by dicode-core PR [#411](https://github.com/dicode-ayo/dicode-core/pull/411) (fixes [dicode-core#406](https://github.com/dicode-ayo/dicode-core/issues/406)), which fixed a crash-loop in the relay daemon task when the relay was unconfigured. Operators who notice `buildin/relay-server-body` absent from the task list or wonder why the relay isn't connecting now have a clear pointer.

Closes #77

## Touched files

- `docs-src/concepts/relay.md` — 4-line info callout added after the Setup snippet, explaining that `relay-server-body` is gated on both `relay.enabled` and `relay.server_url`, that it never starts (no crash-loop, no log noise) without both, and that the reconciler picks up changes within ~30 seconds.

## Originating dicode-core reference

- dicode-ayo/dicode-core#411 (closes dicode-core#406)

## Build

`npm run build` passes clean (VitePress + Vite).


---
_Generated by [Claude Code](https://claude.ai/code/session_01SQ8y4LnsrLzvXWoRnE4oV8)_