### PR TITLE
docs: audit cursor pagination, dicode.audit.query() SDK, and audit-export-loki builtin

### DIFF
--- a/docs-src/concepts/sdk.md
+++ b/docs-src/concepts/sdk.md
@@ -470,6 +470,108 @@ Empty `branch_prefix` is intentionally only legal for `main` / `master` with `al
 
 ---
 
+## dicode.audit.query
+
+Query the daemon's structured audit log from a task script. Returns a page of events and an opaque cursor for resuming. Typical use: a scheduled export task that persists the cursor in `dicode.kv` and resumes each cron run where it left off.
+
+::: warning Sensitive capability
+`audit_query` exposes every security event in the system — actors, targets, denial reasons, and sanitized params. Grant only to tasks that legitimately need audit access. Default-deny: tasks without the capability receive a permission error.
+:::
+
+::: code-group
+
+```ts [Deno]
+export default async function main({ dicode, kv }: DicodeSdk) {
+  const cursor = await kv.get("audit:cursor") as string | null;
+
+  const page = await dicode.audit.query({
+    after:      cursor ?? undefined,
+    order:      "asc",     // oldest-first for a forward export
+    limit:      1000,
+    // Optional filters:
+    // event_type: "denied",
+    // task_id:    "my-task",
+    // actor:      "webhook",
+  });
+
+  for (const event of page.events) {
+    console.log(JSON.stringify(event));
+  }
+
+  if (page.next_cursor) {
+    await kv.set("audit:cursor", page.next_cursor);
+  }
+}
+```
+
+```python [Python]
+cursor = kv.get("audit:cursor")
+
+page = dicode.audit.query(
+    after=cursor,
+    order="asc",
+    limit=1000,
+)
+
+for event in page["events"]:
+    print(event)
+
+if page.get("next_cursor"):
+    kv.set("audit:cursor", page["next_cursor"])
+```
+
+:::
+
+In async Python tasks:
+
+```python
+async def main():
+    cursor = await kv.get_async("audit:cursor")
+    page = await dicode.audit.query_async(after=cursor, order="asc", limit=1000)
+    for event in page["events"]:
+        print(event)
+    if page.get("next_cursor"):
+        await kv.set_async("audit:cursor", page["next_cursor"])
+```
+
+### API
+
+| Method | Deno | Python (sync) | Python (async) |
+|--------|------|---------------|----------------|
+| Query audit log | `await dicode.audit.query(opts?)` | `dicode.audit.query(**opts)` | `await dicode.audit.query_async(**opts)` |
+
+**Options:**
+
+| Option | Type | Description |
+|---|---|---|
+| `after` | string? | Opaque cursor from a previous `next_cursor` |
+| `order` | `"asc"` \| `"desc"` | Sort direction (default `"desc"`) |
+| `limit` | number? | Max events per call (default 100, cap 1000) |
+| `task_id` | string? | Filter by task ID |
+| `actor` | string? | Filter by actor identifier |
+| `event_type` | string? | One of `run_triggered`, `task_called`, `mcp_called`, `denied` |
+
+**Return value:**
+
+```ts
+{
+  events: AuditEvent[];  // up to `limit` events
+  next_cursor?: string;  // present when more results exist; absent otherwise
+}
+```
+
+Each `AuditEvent` matches the response fields documented in [Security & Audit Log — Querying audit events](./security.md#querying-audit-events).
+
+### Required permissions
+
+```yaml
+permissions:
+  dicode:
+    audit_query: true
+```
+
+---
+
 ## mcp
 
 Call tools on **external** MCP (Model Context Protocol) servers exposed by daemon tasks. To go the other direction — let an external MCP client (Claude Desktop, Cursor, Claude Code) call into dicode — see [MCP Server](./mcp-server).

--- a/docs-src/concepts/security.md
+++ b/docs-src/concepts/security.md
@@ -43,7 +43,21 @@ Requires authentication (session cookie or Bearer API key).
 | `after` | Opaque cursor from a previous response's `next_cursor`; resumes from that position (mutually exclusive with `offset`) |
 | `order` | `asc` or `desc` (default `desc` — newest-first) |
 
-Results are returned newest-first as a JSON array. Each entry includes:
+The response is a JSON object. Results are ordered newest-first by default (`order=desc`); pass `order=asc` to reverse.
+
+**Response envelope:**
+
+| Field | Description |
+|---|---|
+| `events` | Array of audit event objects (see per-event fields below) |
+| `count` | Number of events in this page |
+| `next_cursor` | Opaque cursor for the next page; absent when no further results exist. Pass as `after=` on the next request. |
+
+::: tip Cursor vs offset
+Use cursor pagination (`after=` + `next_cursor`) for forward-walking exports. Use `offset=` for random-access page access. Supplying both returns `400`.
+:::
+
+**Per-event fields** (each object in the `events` array):
 
 | Field | Description |
 |---|---|
@@ -58,11 +72,6 @@ Results are returned newest-first as a JSON array. Each entry includes:
 | `run_id` | Associated run ID, when applicable |
 | `allowed` | `true` if the operation was allowed; `false` if denied |
 | `reason` | Denial reason or context note |
-| `next_cursor` | Opaque cursor for the next page; omitted when no further results exist. Pass as `after=` on the next request. |
-
-::: tip Cursor vs offset
-Use cursor pagination (`after=` + `next_cursor`) for forward-walking exports. Use `offset=` for random-access page access. Supplying both returns `400`.
-:::
 
 ### Retention
 

--- a/docs-src/concepts/security.md
+++ b/docs-src/concepts/security.md
@@ -39,7 +39,9 @@ Requires authentication (session cookie or Bearer API key).
 | `actor` | Filter by actor identifier |
 | `event_type` | Filter by event type (`run_triggered`, `task_called`, `mcp_called`, `denied`) |
 | `limit` | Max results (default 100, cap 1000) |
-| `offset` | Pagination offset |
+| `offset` | Offset-based pagination (mutually exclusive with `after`) |
+| `after` | Opaque cursor from a previous response's `next_cursor`; resumes from that position (mutually exclusive with `offset`) |
+| `order` | `asc` or `desc` (default `desc` — newest-first) |
 
 Results are returned newest-first as a JSON array. Each entry includes:
 
@@ -56,6 +58,11 @@ Results are returned newest-first as a JSON array. Each entry includes:
 | `run_id` | Associated run ID, when applicable |
 | `allowed` | `true` if the operation was allowed; `false` if denied |
 | `reason` | Denial reason or context note |
+| `next_cursor` | Opaque cursor for the next page; omitted when no further results exist. Pass as `after=` on the next request. |
+
+::: tip Cursor vs offset
+Use cursor pagination (`after=` + `next_cursor`) for forward-walking exports. Use `offset=` for random-access page access. Supplying both returns `400`.
+:::
 
 ### Retention
 
@@ -73,3 +80,44 @@ audit_log:
 | Negative | Config error — daemon refuses to start |
 
 The daemon prunes expired records at startup and every 6 hours.
+
+### Exporting to Loki / Grafana
+
+The built-in `buildin/audit-export-loki` task exports audit events to a [Grafana Loki](https://grafana.com/oss/loki/) endpoint. It runs on a cron schedule, tracks its position with a cursor in `dicode.kv`, and delivers events at-least-once — deduplicate downstream on the event `id` field.
+
+#### Configuration
+
+| Param / secret | How to supply | Description |
+|---|---|---|
+| `LOKI_ENDPOINT` | task param | Full Loki push URL, e.g. `https://logs.example.com/loki/api/v1/push` |
+| `LOKI_AUTH_TOKEN` | `secret: loki_auth_token` | Bearer token (stored in dicode secrets) |
+
+```bash
+dicode secrets set loki_auth_token "Bearer glc_..."
+```
+
+Configure the endpoint via a taskset override in `dicode.yaml`:
+
+```yaml
+spec:
+  entries:
+    buildin:
+      overrides:
+        entries:
+          audit-export-loki:
+            params:
+              LOKI_ENDPOINT: "https://logs.grafana.net/loki/api/v1/push"
+```
+
+#### Stream labels
+
+Each log line is the full JSON audit event. Stream labels are low-cardinality:
+
+| Label | Value |
+|---|---|
+| `job` | `dicode-audit` |
+| `event_type` | `run_triggered`, `task_called`, `mcp_called`, or `denied` |
+
+#### Adapting to other backends
+
+The poll-batch-push structure (cursor in KV, fetch page, push, advance cursor only on success) is backend-agnostic. Copy `buildin/audit-export-loki` and change the HTTP target and serialization to target Datadog Logs, Elastic, or any other ingest API.

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -113,6 +113,7 @@ permissions:
     list_tasks: true             # dicode.list_tasks()
     get_runs: true               # dicode.get_runs()
     secrets_write: true          # dicode.secrets_set() / secrets_delete()
+    audit_query: true            # dicode.audit.query() — sensitive; see SDK Globals
 
 docker:                          # docker/podman runtime only
   image: nginx:alpine

--- a/docs/theme.html
+++ b/docs/theme.html
@@ -27,9 +27,9 @@
       }
     })();
   </script>
-  <script type="module" crossorigin src="/assets/theme-CDRBVgx0.js"></script>
-  <link rel="modulepreload" crossorigin href="/assets/dc-footer-mSuQBbPo.js">
-  <link rel="stylesheet" crossorigin href="/assets/dc-footer-jIdHI8QF.css">
+  <script type="module" crossorigin src="/assets/theme-kWOkmOjB.js"></script>
+  <link rel="modulepreload" crossorigin href="/assets/dc-footer-CxgFbCDI.js">
+  <link rel="stylesheet" crossorigin href="/assets/dc-footer-CLSIAb2h.css">
 </head>
 <body>
   <dc-nav></dc-nav>


### PR DESCRIPTION
## Summary

Documents three additions from dicode-core PR #416:
- `GET /api/audit` now supports cursor pagination (`after=`, `order=`, `next_cursor`)
- New `dicode.audit.query()` SDK method on Deno and Python with `permissions.dicode.audit_query` gate
- New `buildin/audit-export-loki` task for pushing audit events to Grafana Loki

## Files changed

- `docs-src/concepts/security.md` — cursor params in API table, `next_cursor` in response, new Loki exporter section
- `docs-src/concepts/sdk.md` — new `dicode.audit.query` section with cursor-walking example
- `docs-src/concepts/tasks.md` — `audit_query: true` added to `permissions.dicode` YAML reference

## References

- Closes #80
- dicode-core PR: dicode-ayo/dicode-core#416 (closes dicode-core#415)
- Base audit log PR: dicode-ayo/dicode-core#395

---
_Generated by [Claude Code](https://claude.ai/code/session_014f9vxWHLHvkTxurYvQ4ANc)_