### PR TITLE
docs: auth:false loopback bind, Bearer MCP auth, and trust_proxy Secure cookie

### DIFF
--- a/docs-src/concepts/mcp-server.md
+++ b/docs-src/concepts/mcp-server.md
@@ -16,15 +16,31 @@ Speaks JSON-RPC 2.0 over a single POST per call. The same shape every MCP client
 
 ## Authentication
 
-When `server.auth: true` (the recommended deployment mode), calls to `/mcp` require an API key as a Bearer token. Generate one in the WebUI:
+`/mcp` accepts two authentication mechanisms:
+
+| Mechanism | Header | Use case |
+|---|---|---|
+| **Bearer API key** | `Authorization: Bearer dck_...` | Machine clients, agents, CI — no browser session needed |
+| **Session cookie** | `Cookie: dicode_session=...` | Browser-based tooling that already has a dicode session |
+
+**Bearer API keys are the recommended approach** for all non-browser clients (MCP clients, agents, `curl`, CI pipelines). Generate one in the WebUI:
 
 1. Open the dashboard, go to **Security**
 2. Click **Create API Key**, give it a name
 3. Copy the raw key — it's shown **once** at creation, only its hash is stored
 
-Pass it in the `Authorization` header on every MCP call. Revoke from the same page when a key leaks.
+Pass it in the `Authorization` header on every MCP call:
 
-When `server.auth: false`, `/mcp` is open to anyone who can reach the port — the same trust model as the rest of the API.
+```sh
+curl -X POST http://localhost:8080/mcp \
+  -H "Authorization: Bearer dck_..." \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}'
+```
+
+Revoke from the same Security page when a key leaks.
+
+When `server.auth: false`, `/mcp` is open to anyone who can reach the port — the same trust model as the rest of the API. Note that with `auth: false` the daemon binds to `127.0.0.1` by default; see [`server.host`](/getting-started/configuration#bind-address-serverhost) if you need network access.
 
 ## Tool surface
 

--- a/docs-src/concepts/mcp-server.md
+++ b/docs-src/concepts/mcp-server.md
@@ -40,7 +40,7 @@ curl -X POST http://localhost:8080/mcp \
 
 Revoke from the same Security page when a key leaks.
 
-When `server.auth: false`, `/mcp` is open to anyone who can reach the port — the same trust model as the rest of the API. Note that with `auth: false` the daemon binds to `127.0.0.1` by default; see [`server.host`](/getting-started/configuration#bind-address-serverhost) if you need network access.
+When `server.auth: false`, `/mcp` is open to anyone who can reach the port — the same trust model as the rest of the API. Note that with `auth: false` the daemon binds to `127.0.0.1` by default; see [`server.host`](/getting-started/configuration#bind-address-server-host) if you need network access.
 
 ## Tool surface
 

--- a/docs-src/getting-started/configuration.md
+++ b/docs-src/getting-started/configuration.md
@@ -264,6 +264,8 @@ Set `trust_proxy: true` when dicode runs behind a reverse proxy (nginx, Caddy, T
 `trust_proxy: true` only works correctly when requests actually arrive over HTTPS via a proxy. If you set it with a plain HTTP connection (no proxy in front), browsers will refuse to send the `Secure` cookies and users will be unable to log in.
 
 Do not enable this flag unless dicode is behind a proxy that sets `X-Forwarded-Proto: https`.
+
+Additionally, enabling `trust_proxy` when dicode is directly internet-facing (no proxy) lets any client forge the `X-Forwarded-For` header, causing spoofed IP addresses to appear in the audit log. Only enable this flag when a trusted proxy sits in front of dicode and strips or overwrites those headers before forwarding.
 :::
 
 ## AI

--- a/docs-src/getting-started/configuration.md
+++ b/docs-src/getting-started/configuration.md
@@ -181,10 +181,11 @@ For mobile push (ntfy.sh, gotify, pushover, telegram), webhook integrations (Sla
 ```yaml
 server:
   port: 8080                # HTTP server port (default: 8080)
+  host: ""                  # bind address; default depends on auth (see below)
   auth: false               # enable passphrase auth wall (default: false)
   secret: ""                # passphrase override; leave empty to auto-generate on first boot
   allowed_origins: []       # CORS allowlist; empty = same-origin only
-  trust_proxy: false        # trust X-Forwarded-For headers
+  trust_proxy: false        # trust X-Forwarded-For / X-Forwarded-Proto headers
   mcp: true                 # expose MCP endpoint at /mcp (default: true)
   tray: true                # enable system tray integration
   tls_cert: ""              # path to TLS certificate PEM (enables HTTPS)
@@ -192,6 +193,27 @@ server:
 ```
 
 The server hosts the web UI, the REST API, and the MCP endpoint. When `mcp` is enabled, AI tools like Claude Code and Cursor can discover and call your tasks via the Model Context Protocol.
+
+### Bind address (`server.host`)
+
+The daemon selects its bind address based on the `auth` setting:
+
+| `server.auth` | Default bind address | Reachable from |
+|---|---|---|
+| `false` | `127.0.0.1` | Localhost only |
+| `true` | `0.0.0.0` | All interfaces |
+
+When `auth: false`, dicode binds to **loopback only** (`127.0.0.1`) to prevent accidentally exposing an unauthenticated dashboard to the network. If you run without auth but need network access — for example, behind a reverse proxy that terminates auth itself — set `server.host` explicitly:
+
+```yaml
+server:
+  auth: false
+  host: "0.0.0.0"   # bind to all interfaces (ensure network-level access control)
+```
+
+::: warning
+Running without auth on `0.0.0.0` means anyone on the network can reach the dashboard and trigger tasks. Only do this if the daemon sits behind a trusted reverse proxy or firewall.
+:::
 
 ### Auth passphrase
 
@@ -225,6 +247,24 @@ sqlite3 <datadir>/dicode.db "DELETE FROM kv WHERE key='auth.passphrase';"
 ```
 
 **YAML override behaviour.** When `server.secret` is set, the API refuses passphrase rotation requests with `409 Conflict` to prevent split-brain state between YAML and database. Remove the YAML field to manage the passphrase via the dashboard.
+
+### Reverse proxy (`server.trust_proxy`)
+
+```yaml
+server:
+  trust_proxy: true
+```
+
+Set `trust_proxy: true` when dicode runs behind a reverse proxy (nginx, Caddy, Traefik, etc.) that terminates TLS and forwards requests. This enables two behaviors:
+
+1. **Real IP forwarding** — dicode reads the client IP from `X-Forwarded-For` instead of the TCP connection's remote address. This is required for accurate audit log actor IDs and rate-limit keys.
+2. **`Secure` cookie flag** — session and device cookies are set with `Secure: true`, so browsers only send them over HTTPS.
+
+::: warning
+`trust_proxy: true` only works correctly when requests actually arrive over HTTPS via a proxy. If you set it with a plain HTTP connection (no proxy in front), browsers will refuse to send the `Secure` cookies and users will be unable to log in.
+
+Do not enable this flag unless dicode is behind a proxy that sets `X-Forwarded-Proto: https`.
+:::
 
 ## AI
 


### PR DESCRIPTION
## Summary

Documents three operator-visible behavior changes introduced in dicode-core#424 (merged 2026-06-17, closes dicode-core#384).

Closes dicode-ayo/dicode-site#83.

## Changes

| File | Change |
|---|---|
| `docs-src/getting-started/configuration.md` | Added `server.host` field to YAML example; new **Bind address** section explaining that `auth: false` now binds to `127.0.0.1` only and how to override with `server.host: "0.0.0.0"`; new **Reverse proxy** section explaining that `trust_proxy: true` sets the `Secure` cookie flag and requires HTTPS |
| `docs-src/concepts/mcp-server.md` | Expanded Authentication section to explicitly document Bearer API key support; added mechanism comparison table; added `curl` example; cross-linked to new `server.host` docs |

## Reference

- dicode-core PR: dicode-ayo/dicode-core#424
- Tracks: dicode-ayo/dicode-site#83

---
_Generated by [Claude Code](https://claude.ai/code/session_018T3s1jkUxhT8Uf4mcYYD97)_