### PR TITLE
docs: document Docker template variable expansion in command/entrypoint/working_dir/build fields

### DIFF
--- a/docs-src/concepts/runtimes.md
+++ b/docs-src/concepts/runtimes.md
@@ -232,6 +232,28 @@ docker:
   pull_policy: missing    # always | missing (default) | never
 ```
 
+::: tip Template variable expansion in Docker fields
+`${VAR}` substitution is supported in `command`, `entrypoint`, `working_dir`,
+`build.context`, `build.dockerfile`, and `volumes`. The most useful built-in is
+`${TASK_DIR}`, which resolves to the absolute path of the task's own directory.
+
+```yaml
+docker:
+  build:
+    context: "${TASK_DIR}"
+    dockerfile: "${TASK_DIR}/Dockerfile"
+  volumes:
+    - "${TASK_DIR}/config:/app/config:ro"
+```
+
+Daemon process environment variables are **not** a fallback in these fields
+(`envFallback: false`). To pass host env vars into the container, use
+`permissions.env` and `docker.env_vars`.
+
+See [Template variables](/concepts/tasks#template-variables) for the full list of
+supported fields and built-in variables.
+:::
+
 ### Daemon containers
 
 Docker tasks work well as daemons -- long-running services that start with dicode:

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -86,6 +86,7 @@ params:
     required: true
 
 permissions:
+  env_read_exposed: false        # Deno only: grant bare --allow-env (read any env var)
   env:
     - HOME                       # allowlist host env var
     - name: API_KEY              # rename from host env
@@ -228,13 +229,13 @@ Required when `runtime` is `docker` or `podman`. Must specify either `image` or 
 | Field | Description |
 |-------|-------------|
 | `image` | Docker image to pull (e.g. `nginx:alpine`) |
-| `build.dockerfile` | Path to Dockerfile, relative to task dir |
-| `build.context` | Build context directory, relative to task dir |
-| `command` | Override image CMD |
-| `entrypoint` | Override image ENTRYPOINT |
-| `volumes` | Bind mounts in `host:container[:ro]` format |
+| `build.dockerfile` | Path to Dockerfile, relative to task dir. Supports `${VAR}` expansion. |
+| `build.context` | Build context directory, relative to task dir. Supports `${VAR}` expansion. |
+| `command` | Override image CMD. Supports `${VAR}` expansion. |
+| `entrypoint` | Override image ENTRYPOINT. Supports `${VAR}` expansion. |
+| `volumes` | Bind mounts in `host:container[:ro]` format. Supports `${VAR}` expansion. |
 | `ports` | Port mappings in `hostPort:containerPort` format |
-| `working_dir` | Container working directory |
+| `working_dir` | Container working directory. Supports `${VAR}` expansion. |
 | `env_vars` | Extra environment variables (literal values) |
 | `pull_policy` | `always`, `missing` (default), or `never` |
 
@@ -318,11 +319,63 @@ See [Secrets](./secrets.md) for details on `permissions.env` and secret injectio
 For Deno tasks, permissions map directly to Deno's `--allow-*` flags. Python and Docker tasks use env injection only (`permissions.env`).
 :::
 
+### Permissions field reference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `env` | list | Env vars the task may read; each entry is a bare name, `from:` rename, `secret:` injection, or literal `value:`. See [Secrets](./secrets.md). |
+| `env_read_exposed` | bool | **Deno only.** Grant bare `--allow-env` (read any env var). Default `false`. See below. |
+| `fs` | list | **Deno only.** Filesystem paths and access modes (`r`, `w`, `rw`). |
+| `run` | list | Executables the script may spawn (`Deno.Command` / Python `subprocess`). Use `["*"]` for all; omit to deny all. |
+| `net` | list | Outbound network hostnames. Use `["*"]` for all; omit to deny all. |
+| `sys` | list | **Deno only.** System-info APIs (`hostname`, `osRelease`, …). |
+| `dicode` | object | dicode runtime API access (`tasks`, `mcp`, `list_tasks`, `get_runs`, `secrets_write`). |
+
+### `env_read_exposed` — grant unrestricted env read (Deno / npm escape hatch)
+
+`permissions.env_read_exposed: true` grants the Deno subprocess bare `--allow-env`, allowing it to read **any** env var. It exists for tasks that import npm packages via `npm:` specifiers: transitive dependencies often read `process.env` keys (such as `NODE_ENV`) at module-init time, before `main()` runs. Because that set of keys is unpredictable per dependency, listing individual names in `env:` is fragile — the import will still throw `NotCapable` for any key not declared.
+
+`env_read_exposed` widens *read permission* only and is independent of the `env:` list. Keep named/`secret:`/`from:` entries for variables that need to be **forwarded** (injected into the subprocess env); the flag grants permission to read a var but does not inject values:
+
+```yaml
+permissions:
+  env_read_exposed: true   # allow reading any env var (node-compat import needs this)
+  env:
+    - DICODE_DATADIR        # still forwarded so the script's value is populated
+    - DICODE_VERSION
+```
+
+**Why this is safe.** A task subprocess does not inherit the full daemon environment. The subprocess env is assembled as an allowlist: process basics, cache/proxy/TLS vars, the per-run IPC coordinates (`DICODE_SOCKET`/`DICODE_TOKEN`), host values of the task's own named `env:` entries, and resolved secrets. The daemon master key and admin/MCP API keys are explicitly denylisted and never forwarded. Bare `--allow-env` therefore exposes only the already-task-scoped env — nothing the task did not already hold.
+
+**Constraints:**
+
+- Only settable in the task's own `task.yaml`. Taskset `overrides:` blocks cannot set `env_read_exposed`.
+- Toggling the flag changes the task's content hash, which re-pends the task at the approval gate.
+- Deno only. Python tasks read env through the SDK (`env.get()`), which is not gated by `--allow-env`; this flag is silently ignored on Python, Docker, and Podman runtimes.
+
+::: warning Validation error for `env: ["*"]`
+A bare `"*"` entry in the `env:` list is now a **validation error**. Use `env_read_exposed: true` instead.
+:::
+
 ## Template variables
 
 A tight allowlist of fields in `task.yaml` support `${VAR}` substitution, resolved at task-load time. Use them for paths and indirection keys that depend on where the task is loaded from.
 
-**Supported fields:** `permissions.fs[].path`, `trigger.webhook_secret`, and `permissions.env[].from | .secret | .value`. Everything else is taken literally.
+**Supported fields:**
+
+| Field | Notes |
+| --- | --- |
+| `permissions.fs[].path` | |
+| `trigger.webhook_secret` | |
+| `permissions.env[].from \| .secret \| .value` | |
+| `docker.command` | `envFallback` off — see below |
+| `docker.entrypoint` | `envFallback` off — see below |
+| `docker.working_dir` | `envFallback` off — see below |
+| `docker.build.context` | `envFallback` off — see below |
+| `docker.build.dockerfile` | `envFallback` off — see below |
+| `docker.volumes` | `envFallback` off — see below |
+
+Everything else is taken literally.
 
 **Built-in variables:**
 
@@ -334,6 +387,12 @@ A tight allowlist of fields in `task.yaml` support `${VAR}` substitution, resolv
 | `${SKILLS_DIR}` | Auto-derived as `${SOURCE_ROOT}/skills` |
 
 Resolution order: built-ins → process env → **leave literal** (unknown `${VAR}` references stay in place so bugs surface loudly rather than silently collapsing to an empty string).
+
+::: warning Docker fields: daemon env vars are not a fallback
+For all `docker.*` fields listed above, `envFallback` is **off**: built-in variables (`${TASK_DIR}`, `${DATADIR}`, etc.) are expanded, but daemon process environment variables are **not** accessible as a fallback. An unrecognised `${VAR}` reference is left as-is rather than silently replaced with a daemon env var value.
+
+This matches the existing behaviour of `docker.volumes` and is intentional — Docker tasks declare their env access via `permissions.env`, not through template substitution.
+:::
 
 **Example: reference the shared skills directory regardless of source type:**
 
@@ -353,4 +412,17 @@ trigger:
 permissions:
   env:
     - GITHUB_WEBHOOK_SECRET
+```
+
+**Example: use `${TASK_DIR}` in Docker fields to mount or reference files from the task directory:**
+
+```yaml
+docker:
+  build:
+    context: "${TASK_DIR}"
+    dockerfile: "${TASK_DIR}/Dockerfile"
+  working_dir: /app
+  volumes:
+    - "${TASK_DIR}/config:/app/config:ro"
+  command: ["python", "main.py", "--data", "/data"]
 ```

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -86,7 +86,7 @@ params:
     required: true
 
 permissions:
-  env_read_exposed: false        # Deno only: grant bare --allow-env (read any env var)
+  env_read_exposed: false        # Deno only: set true to grant bare --allow-env (off by default)
   env:
     - HOME                       # allowlist host env var
     - name: API_KEY              # rename from host env
@@ -325,7 +325,7 @@ For Deno tasks, permissions map directly to Deno's `--allow-*` flags. Python and
 |-------|------|-------------|
 | `env` | list | Env vars the task may read; each entry is a bare name, `from:` rename, `secret:` injection, or literal `value:`. See [Secrets](./secrets.md). |
 | `env_read_exposed` | bool | **Deno only.** Grant bare `--allow-env` (read any env var). Default `false`. See below. |
-| `fs` | list | **Deno only.** Filesystem paths and access modes (`r`, `w`, `rw`). |
+| `fs` | list | **Deno (read + write); Python (write mode only).** Filesystem paths and access modes (`r`, `w`, `rw`). |
 | `run` | list | Executables the script may spawn (`Deno.Command` / Python `subprocess`). Use `["*"]` for all; omit to deny all. |
 | `net` | list | Outbound network hostnames. Use `["*"]` for all; omit to deny all. |
 | `sys` | list | **Deno only.** System-info APIs (`hostname`, `osRelease`, …). |
@@ -335,7 +335,7 @@ For Deno tasks, permissions map directly to Deno's `--allow-*` flags. Python and
 
 `permissions.env_read_exposed: true` grants the Deno subprocess bare `--allow-env`, allowing it to read **any** env var. It exists for tasks that import npm packages via `npm:` specifiers: transitive dependencies often read `process.env` keys (such as `NODE_ENV`) at module-init time, before `main()` runs. Because that set of keys is unpredictable per dependency, listing individual names in `env:` is fragile — the import will still throw `NotCapable` for any key not declared.
 
-`env_read_exposed` widens *read permission* only and is independent of the `env:` list. Keep named/`secret:`/`from:` entries for variables that need to be **forwarded** (injected into the subprocess env); the flag grants permission to read a var but does not inject values:
+`env_read_exposed` widens *read permission* only and is independent of the `env:` list. Named `env:` entries already grant per-variable read permission (they appear in `--allow-env=FOO,BAR,...`) and inject values into the subprocess env. The flag is needed only when a transitive dependency reads env vars that are **not** declared in `env:`. Keep named/`secret:`/`from:` entries for variables the task explicitly declares; add the flag only if npm-compat imports still fail:
 
 ```yaml
 permissions:

--- a/docs-src/examples/docker-task.md
+++ b/docs-src/examples/docker-task.md
@@ -165,8 +165,8 @@ the task's own directory.
 `docker.build.context`, `docker.build.dockerfile`, and `docker.volumes` all
 expand template variables.
 
-`docker.image`, `docker.ports`, and `docker.env` do **not** expand variables —
-their values are taken literally.
+`docker.image`, `docker.ports`, and `docker.env_vars` do **not** expand
+variables — their values are taken literally.
 :::
 
 ::: warning Daemon env vars are not a fallback

--- a/docs-src/examples/docker-task.md
+++ b/docs-src/examples/docker-task.md
@@ -154,18 +154,70 @@ docker:
     dockerfile: Dockerfile
 ```
 
+## Template variable expansion
+
+Several `docker:` fields support `${VAR}` substitution, resolved at task-load
+time. The most useful built-in is `${TASK_DIR}`, which is the absolute path to
+the task's own directory.
+
+::: tip Which fields expand `${VAR}`?
+`docker.command`, `docker.entrypoint`, `docker.working_dir`,
+`docker.build.context`, `docker.build.dockerfile`, and `docker.volumes` all
+expand template variables.
+
+`docker.image`, `docker.ports`, and `docker.env` do **not** expand variables —
+their values are taken literally.
+:::
+
+::: warning Daemon env vars are not a fallback
+The expansion policy is `envFallback: false`. Built-in variables such as
+`${TASK_DIR}` and `${DATADIR}` are resolved, but daemon process environment
+variables are **not** accessible as a fallback. An unrecognised `${VAR}`
+reference is left as-is rather than replaced with a daemon env var value. To
+pass host env vars into a container, use `permissions.env` and `docker.env_vars`.
+:::
+
+### Example: Dockerfile build using `${TASK_DIR}`
+
+```yaml
+apiVersion: dicode/v1
+kind: Task
+name: App Builder
+description: Builds from the task directory and mounts local config
+runtime: docker
+
+trigger:
+  manual: true
+
+docker:
+  build:
+    context: "${TASK_DIR}"
+    dockerfile: "${TASK_DIR}/Dockerfile"
+  working_dir: /app
+  volumes:
+    - "${TASK_DIR}/config:/app/config:ro"
+  command: ["python", "main.py"]
+```
+
+This guarantees the build context and Dockerfile paths resolve to the correct
+absolute location regardless of how or where dicode is run.
+
 ## Configuration reference
 
 The full set of `docker` fields available in task.yaml:
 
-| Field | Description |
-| --- | --- |
-| `docker.image` | Container image to use (e.g. `nginx:alpine`) |
-| `docker.build.dockerfile` | Path to Dockerfile, relative to the task directory |
-| `docker.ports` | List of port mappings (`host:container`) |
-| `docker.volumes` | List of volume mounts (`host:container[:options]`) |
-| `docker.pull_policy` | When to pull: `always`, `missing`, or `never` |
-| `docker.env` | Additional environment variables to pass to the container |
+| Field | `${VAR}` expansion | Description |
+| --- | --- | --- |
+| `docker.image` | no | Container image to use (e.g. `nginx:alpine`) |
+| `docker.build.dockerfile` | **yes** | Path to Dockerfile, relative to the task directory |
+| `docker.build.context` | **yes** | Build context directory, relative to the task directory |
+| `docker.command` | **yes** | Override image CMD |
+| `docker.entrypoint` | **yes** | Override image ENTRYPOINT |
+| `docker.working_dir` | **yes** | Container working directory |
+| `docker.volumes` | **yes** | List of volume mounts (`host:container[:options]`) |
+| `docker.ports` | no | List of port mappings (`host:container`) |
+| `docker.pull_policy` | no | When to pull: `always`, `missing`, or `never` |
+| `docker.env_vars` | no | Additional environment variables to pass to the container |
 
 When `docker.build` is set, `docker.image` is ignored -- dicode builds and
 tags the image automatically.

--- a/docs/theme.html
+++ b/docs/theme.html
@@ -27,9 +27,9 @@
       }
     })();
   </script>
-  <script type="module" crossorigin src="/assets/theme-CDRBVgx0.js"></script>
-  <link rel="modulepreload" crossorigin href="/assets/dc-footer-mSuQBbPo.js">
-  <link rel="stylesheet" crossorigin href="/assets/dc-footer-jIdHI8QF.css">
+  <script type="module" crossorigin src="/assets/theme-kWOkmOjB.js"></script>
+  <link rel="modulepreload" crossorigin href="/assets/dc-footer-CxgFbCDI.js">
+  <link rel="stylesheet" crossorigin href="/assets/dc-footer-CLSIAb2h.css">
 </head>
 <body>
   <dc-nav></dc-nav>


### PR DESCRIPTION
## Summary

Adds documentation for the template variable expansion fix landed in [dicode-core#425](https://github.com/dicode-ayo/dicode-core/pull/425), which closed [dicode-core#386](https://github.com/dicode-ayo/dicode-core/issues/386).

Closes #84.

Prior to dicode-core#425, `${TASK_DIR}` and `${DATADIR}` were silently **not** expanded in Docker task fields — they were passed through as literal strings to the container runtime. The fix makes expansion consistent across all path-bearing Docker fields.

### Touched files

| File | Reason |
| --- | --- |
| `docs-src/concepts/tasks.md` | Expanded the "Template variables" supported-fields list to include all six Docker fields; added `envFallback=false` warning callout; added Docker example; updated the Docker runtime config field table to flag each expandable field |
| `docs-src/concepts/runtimes.md` | Added a tip callout in the Docker section pointing out `${VAR}` support and the `envFallback=false` policy |
| `docs-src/examples/docker-task.md` | Added a "Template variable expansion" section with an example, a which-fields-expand tip, an envFallback warning; updated config reference table to add a `${VAR}` expansion column |

### What changed functionally (dicode-core#425)

The fields that **now** expand template variables (in addition to the pre-existing `docker.volumes`):
- `docker.command`
- `docker.entrypoint`
- `docker.working_dir`
- `docker.build.context`
- `docker.build.dockerfile`

Expansion policy: `envFallback=false` — built-in variables (`${TASK_DIR}`, `${DATADIR}`, etc.) resolve, but daemon process env vars do **not** serve as a fallback.

## Test plan

- [ ] `npm run build` passes with no errors or broken-link warnings
- [ ] Template variables section in `/concepts/tasks` now lists all six Docker fields
- [ ] Docker fields table in `/concepts/tasks` shows `${VAR}` expansion notes
- [ ] `/concepts/runtimes` Docker section has the new tip callout
- [ ] `/examples/docker-task` has the new "Template variable expansion" section and updated config table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018T3s1jkUxhT8Uf4mcYYD97)_