### PR TITLE
docs: document permissions.env_read_exposed flag for Deno npm tasks

### DIFF
--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -86,7 +86,7 @@ params:
     required: true
 
 permissions:
-  env_read_exposed: false        # Deno only: grant bare --allow-env (read any env var)
+  env_read_exposed: false        # Deno only: set true to grant bare --allow-env (off by default)
   env:
     - HOME                       # allowlist host env var
     - name: API_KEY              # rename from host env
@@ -325,7 +325,7 @@ For Deno tasks, permissions map directly to Deno's `--allow-*` flags. Python and
 |-------|------|-------------|
 | `env` | list | Env vars the task may read; each entry is a bare name, `from:` rename, `secret:` injection, or literal `value:`. See [Secrets](./secrets.md). |
 | `env_read_exposed` | bool | **Deno only.** Grant bare `--allow-env` (read any env var). Default `false`. See below. |
-| `fs` | list | **Deno only.** Filesystem paths and access modes (`r`, `w`, `rw`). |
+| `fs` | list | **Deno (read + write); Python (write mode only).** Filesystem paths and access modes (`r`, `w`, `rw`). |
 | `run` | list | Executables the script may spawn (`Deno.Command` / Python `subprocess`). Use `["*"]` for all; omit to deny all. |
 | `net` | list | Outbound network hostnames. Use `["*"]` for all; omit to deny all. |
 | `sys` | list | **Deno only.** System-info APIs (`hostname`, `osRelease`, …). |
@@ -335,7 +335,7 @@ For Deno tasks, permissions map directly to Deno's `--allow-*` flags. Python and
 
 `permissions.env_read_exposed: true` grants the Deno subprocess bare `--allow-env`, allowing it to read **any** env var. It exists for tasks that import npm packages via `npm:` specifiers: transitive dependencies often read `process.env` keys (such as `NODE_ENV`) at module-init time, before `main()` runs. Because that set of keys is unpredictable per dependency, listing individual names in `env:` is fragile — the import will still throw `NotCapable` for any key not declared.
 
-`env_read_exposed` widens *read permission* only and is independent of the `env:` list. Keep named/`secret:`/`from:` entries for variables that need to be **forwarded** (injected into the subprocess env); the flag grants permission to read a var but does not inject values:
+`env_read_exposed` widens *read permission* only and is independent of the `env:` list. Named `env:` entries already grant per-variable read permission (they appear in `--allow-env=FOO,BAR,...`) and inject values into the subprocess env. The flag is needed only when a transitive dependency reads env vars that are **not** declared in `env:`. Keep named/`secret:`/`from:` entries for variables the task explicitly declares; add the flag only if npm-compat imports still fail:
 
 ```yaml
 permissions:
@@ -350,7 +350,7 @@ permissions:
 **Constraints:**
 
 - Only settable in the task's own `task.yaml`. Taskset `overrides:` blocks cannot set `env_read_exposed`.
-- Toggling the flag changes the task's content hash, which re-pends the task at the approval gate.
+- Toggling the flag changes the task's content hash, which re-pends the task at the approval gate (if the approval gate is enabled via `approval.enabled: true` in `dicode.yaml`).
 - Deno only. Python tasks read env via `os.environ` directly (the subprocess env is already bounded by `SubprocessEnv`); this flag is silently ignored on Python, Docker, and Podman runtimes.
 
 ::: warning Validation error for `env: ["*"]`

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -345,13 +345,13 @@ permissions:
     - DICODE_VERSION
 ```
 
-**Why this is safe.** A task subprocess does not inherit the full daemon environment. The subprocess env is assembled as an allowlist: process basics, cache/proxy/TLS vars, the per-run IPC coordinates (`DICODE_SOCKET`/`DICODE_TOKEN`), host values of the task's own named `env:` entries, and resolved secrets. The daemon master key and admin/MCP API keys are explicitly denylisted and never forwarded. Bare `--allow-env` therefore exposes only the already-task-scoped env — nothing the task did not already hold.
+**Why this is safe.** A task subprocess does not inherit the full daemon environment. The subprocess env is assembled as an allowlist: process basics, cache/proxy/TLS passthrough vars (`PATH`, `HOME`, `HTTP_PROXY`, `HTTPS_PROXY`, `SSL_CERT_FILE`, `DENO_DIR`, etc. — needed by the runtime toolchain), the per-run IPC coordinates (`DICODE_SOCKET`/`DICODE_TOKEN`), host values of the task's own named `env:` entries, and resolved secrets. The daemon master key and admin/MCP API keys are explicitly denylisted and never forwarded. Bare `--allow-env` therefore exposes only that already-task-scoped env — nothing the task did not already hold. Operators should be aware that the proxy/TLS passthrough vars are readable under this flag; avoid embedding credentials in `HTTP_PROXY`/`HTTPS_PROXY` URLs on hosts running tasks with this flag.
 
 **Constraints:**
 
 - Only settable in the task's own `task.yaml`. Taskset `overrides:` blocks cannot set `env_read_exposed`.
 - Toggling the flag changes the task's content hash, which re-pends the task at the approval gate.
-- Deno only. Python tasks read env through the SDK (`env.get()`), which is not gated by `--allow-env`; this flag is silently ignored on Python, Docker, and Podman runtimes.
+- Deno only. Python tasks read env via `os.environ` directly (the subprocess env is already bounded by `SubprocessEnv`); this flag is silently ignored on Python, Docker, and Podman runtimes.
 
 ::: warning Validation error for `env: ["*"]`
 A bare `"*"` entry in the `env:` list is now a **validation error**. Use `env_read_exposed: true` instead.

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -86,6 +86,7 @@ params:
     required: true
 
 permissions:
+  env_read_exposed: false        # Deno only: grant bare --allow-env (read any env var)
   env:
     - HOME                       # allowlist host env var
     - name: API_KEY              # rename from host env
@@ -316,6 +317,44 @@ See [Secrets](./secrets.md) for details on `permissions.env` and secret injectio
 
 ::: tip
 For Deno tasks, permissions map directly to Deno's `--allow-*` flags. Python and Docker tasks use env injection only (`permissions.env`).
+:::
+
+### Permissions field reference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `env` | list | Env vars the task may read; each entry is a bare name, `from:` rename, `secret:` injection, or literal `value:`. See [Secrets](./secrets.md). |
+| `env_read_exposed` | bool | **Deno only.** Grant bare `--allow-env` (read any env var). Default `false`. See below. |
+| `fs` | list | **Deno only.** Filesystem paths and access modes (`r`, `w`, `rw`). |
+| `run` | list | Executables the script may spawn (`Deno.Command` / Python `subprocess`). Use `["*"]` for all; omit to deny all. |
+| `net` | list | Outbound network hostnames. Use `["*"]` for all; omit to deny all. |
+| `sys` | list | **Deno only.** System-info APIs (`hostname`, `osRelease`, …). |
+| `dicode` | object | dicode runtime API access (`tasks`, `mcp`, `list_tasks`, `get_runs`, `secrets_write`). |
+
+### `env_read_exposed` — grant unrestricted env read (Deno / npm escape hatch)
+
+`permissions.env_read_exposed: true` grants the Deno subprocess bare `--allow-env`, allowing it to read **any** env var. It exists for tasks that import npm packages via `npm:` specifiers: transitive dependencies often read `process.env` keys (such as `NODE_ENV`) at module-init time, before `main()` runs. Because that set of keys is unpredictable per dependency, listing individual names in `env:` is fragile — the import will still throw `NotCapable` for any key not declared.
+
+`env_read_exposed` widens *read permission* only and is independent of the `env:` list. Keep named/`secret:`/`from:` entries for variables that need to be **forwarded** (injected into the subprocess env); the flag grants permission to read a var but does not inject values:
+
+```yaml
+permissions:
+  env_read_exposed: true   # allow reading any env var (node-compat import needs this)
+  env:
+    - DICODE_DATADIR        # still forwarded so the script's value is populated
+    - DICODE_VERSION
+```
+
+**Why this is safe.** A task subprocess does not inherit the full daemon environment. The subprocess env is assembled as an allowlist: process basics, cache/proxy/TLS vars, the per-run IPC coordinates (`DICODE_SOCKET`/`DICODE_TOKEN`), host values of the task's own named `env:` entries, and resolved secrets. The daemon master key and admin/MCP API keys are explicitly denylisted and never forwarded. Bare `--allow-env` therefore exposes only the already-task-scoped env — nothing the task did not already hold.
+
+**Constraints:**
+
+- Only settable in the task's own `task.yaml`. Taskset `overrides:` blocks cannot set `env_read_exposed`.
+- Toggling the flag changes the task's content hash, which re-pends the task at the approval gate.
+- Deno only. Python tasks read env through the SDK (`env.get()`), which is not gated by `--allow-env`; this flag is silently ignored on Python, Docker, and Podman runtimes.
+
+::: warning Validation error for `env: ["*"]`
+A bare `"*"` entry in the `env:` list is now a **validation error**. Use `env_read_exposed: true` instead.
 :::
 
 ## Template variables


### PR DESCRIPTION
## Summary

Resolves dicode-site#82. Documents the `permissions.env_read_exposed` flag added in [dicode-core#413](https://github.com/dicode-ayo/dicode-core/pull/413) (merged 2026-06-17).

## Touched files

| File | Reason |
|------|--------|
| `docs-src/concepts/tasks.md` | Added `env_read_exposed: false` to the full `task.yaml` example; added a Permissions field reference table; added a `### env_read_exposed` subsection explaining semantics, safety, constraints, and the validation error for `env: ["*"]` |

## What changed in the source

- `permissions.env_read_exposed: true` grants the Deno subprocess bare `--allow-env` (read any env var).
- Exists for npm/node-compat tasks whose transitive deps enumerate `process.env` at module-init time — individual `env:` entries are insufficient because the key set is unpredictable.
- Widens *read permission* only; named/`secret:`/`from:` entries still control what is *forwarded* (injected).
- Only settable in the task's own `task.yaml` — taskset `overrides:` cannot set it.
- Folded into the approval-gate content hash — toggling re-pends the task.
- A bare `"*"` in `permissions.env` is now a validation error pointing to this flag.
- Deno only; silently ignored on Python, Docker, and Podman runtimes.

## References

- dicode-site issue: dicode-ayo/dicode-site#82
- dicode-core PR: dicode-ayo/dicode-core#413

---
_Generated by [Claude Code](https://claude.ai/code/session_018T3s1jkUxhT8Uf4mcYYD97)_