### PR TITLE
docs: v0.4.0 breaking permission changes — permissions.net default-deny and Python PEP 578 enforcement

### DIFF
--- a/docs-src/concepts/runtimes.md
+++ b/docs-src/concepts/runtimes.md
@@ -160,6 +160,41 @@ Use the `env` global:
 token = env.get("GITHUB_TOKEN")
 ```
 
+### Permissions enforcement (v0.4.0+)
+
+Since v0.4.0, `permissions.fs`, `permissions.net`, and `permissions.run` declared in `task.yaml` are enforced at runtime via a [PEP 578](https://peps.python.org/pep-0578/) audit hook installed in the Python subprocess before your script runs.
+
+Attempting to access an undeclared resource raises `PermissionError`:
+
+```
+PermissionError: [dicode] fs access denied for '/etc/passwd': declare path under permissions.fs
+PermissionError: [dicode] network access denied for 'api.example.com': add to permissions.net
+PermissionError: [dicode] subprocess denied for 'git': add to permissions.run
+```
+
+Declare these the same way as Deno tasks:
+
+```yaml
+permissions:
+  fs:
+    - path: /tmp/reports
+      permission: rw          # r | w | rw
+  net:
+    - api.example.com
+    - "*.s3.amazonaws.com"
+  run:
+    - git
+    - ffmpeg
+```
+
+::: warning Breaking change in v0.4.0
+Before v0.4.0, `permissions.fs`, `permissions.net`, and `permissions.run` were parsed from `task.yaml` but **not enforced** — the Python subprocess inherited host-level access. Since v0.4.0, undeclared filesystem access, network connections, and subprocess spawns raise `PermissionError` at runtime.
+
+If you are upgrading from v0.3.x, audit your Python tasks and add explicit permission declarations for every file path, hostname, and executable they access.
+:::
+
+`permissions.env` and `permissions.dicode` are unaffected by this change and work the same as before.
+
 ---
 
 ## Docker

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -332,6 +332,21 @@ For Deno tasks, permissions map directly to Deno's `--allow-*` flags. Python and
 | `sys` | list | **Deno only.** System-info APIs (`hostname`, `osRelease`, …). |
 | `dicode` | object | dicode runtime API access (`tasks`, `mcp`, `list_tasks`, `get_runs`, `secrets_write`). |
 
+::: warning Breaking change in v0.4.0
+Before v0.4.0, omitting `permissions.net` from a Deno task granted **unrestricted outbound network access**. Since v0.4.0 the default is **deny** — a task without `permissions.net` cannot make any outbound network connections.
+
+If you are upgrading from v0.3.x, add a `net:` declaration to any Deno task that makes HTTP/HTTPS calls:
+
+```yaml
+permissions:
+  net:
+    - api.github.com          # specific hostname
+    - "*.example.com"         # wildcard subdomain
+    # or:
+  net: ["*"]                  # allow all outbound (less secure)
+```
+:::
+
 ### `env_read_exposed` — grant unrestricted env read (Deno / npm escape hatch)
 
 `permissions.env_read_exposed: true` grants the Deno subprocess bare `--allow-env`, allowing it to read **any** env var. It exists for tasks that import npm packages via `npm:` specifiers: transitive dependencies often read `process.env` keys (such as `NODE_ENV`) at module-init time, before `main()` runs. Because that set of keys is unpredictable per dependency, listing individual names in `env:` is fragile — the import will still throw `NotCapable` for any key not declared.


### PR DESCRIPTION
## Summary

- **`tasks.md`**: Added a `:::warning` callout after the permissions field reference table documenting that `permissions.net` flipped to default-deny in v0.4.0, with upgrade guidance and YAML examples.
- **`runtimes.md`**: Added a new `### Permissions enforcement (v0.4.0+)` subsection in the Python section covering the PEP 578 audit hook, `PermissionError` messages, declaration syntax, and a breaking-change callout.

## Related issues and PRs

Closes #90

### Originating dicode-core references
- `permissions.net` default-deny: dicode-ayo/dicode-core#379 / dicode-ayo/dicode-core#394
- Python PEP 578 enforcement: dicode-ayo/dicode-core#390
- Release: dicode-ayo/dicode-core#370 (v0.4.0, merged 2026-06-18)

## Files changed

| File | Change |
|------|--------|
| `docs-src/concepts/tasks.md` | Added `:::warning Breaking change in v0.4.0` callout after permissions field table — net default-deny, upgrade instructions, YAML examples |
| `docs-src/concepts/runtimes.md` | Added `### Permissions enforcement (v0.4.0+)` section in Python runtime — PEP 578 audit hook, PermissionError messages, declaration examples, breaking-change callout |

## Test plan

- [ ] `npm ci && npm run build` passes clean (validated locally before push)
- [ ] Warning callout renders correctly in VitePress (`::: warning` syntax)
- [ ] New `### Permissions enforcement` section appears in Python runtime section of the rendered docs
- [ ] Upgrade guidance YAML examples are syntactically valid
- [ ] No broken internal links introduced

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4whvFDqNPJ5MnD4CFp6Fr)_