### PR TITLE
docs: document task write-protection on dicode.lock and dicode.yaml

### DIFF
--- a/docs-src/concepts/security.md
+++ b/docs-src/concepts/security.md
@@ -130,3 +130,15 @@ Each log line is the full JSON audit event. Stream labels are low-cardinality:
 #### Adapting to other backends
 
 The poll-batch-push structure (cursor in KV, fetch page, push, advance cursor only on success) is backend-agnostic. Copy `buildin/audit-export-loki` and change the HTTP target and serialization to target Datadog Logs, Elastic, or any other ingest API.
+
+## Task write protections
+
+dicode unconditionally write-protects two daemon files from all task code: `dicode.lock` and `dicode.yaml`. This protection is enforced at the runtime level and cannot be overridden by taskset `overrides:` blocks or any `permissions.fs` grant.
+
+- **Deno runtime:** the subprocess is launched with `--deny-write=<dicode.lock>,<dicode.yaml>`. Deno's `--deny-write` flag takes precedence over any `--allow-write` grant, including a broad path covering the config directory. Write or remove attempts return `NotCapable`.
+- **Python runtime:** a PEP 578 audit hook checks the `fs_deny` list before the write allowlist. Writes to these paths raise `PermissionError` even when a broad `permissions.fs` write grant covers the config directory.
+- Paths are canonicalized (symlinks resolved) before comparison, so the deny entry matches even when the config directory is reached via a symlink.
+
+The reason these files are protected is that they hold the approval-gate state: `dicode.lock` records approval decisions for pending tasks, and `dicode.yaml` is the daemon configuration. A task with a broad filesystem write grant that could overwrite `dicode.lock` could self-approve other pending tasks, bypassing the approval gate entirely.
+
+See [Permissions field reference](./tasks.md#permissions-field-reference) for the `permissions.fs` declaration syntax.

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -326,11 +326,15 @@ For Deno tasks, permissions map directly to Deno's `--allow-*` flags. Python and
 |-------|------|-------------|
 | `env` | list | Env vars the task may read; each entry is a bare name, `from:` rename, `secret:` injection, or literal `value:`. See [Secrets](./secrets.md). |
 | `env_read_exposed` | bool | **Deno only.** Grant bare `--allow-env` (read any env var). Default `false`. See below. |
-| `fs` | list | **Deno (read + write); Python (write mode only).** Filesystem paths and access modes (`r`, `w`, `rw`). |
+| `fs` | list | **Deno (read + write); Python (write mode only).** Filesystem paths and access modes (`r`, `w`, `rw`). See write-protection note below. |
 | `run` | list | Executables the script may spawn (`Deno.Command` / Python `subprocess`). Use `["*"]` for all; omit to deny all. |
 | `net` | list | Outbound network hostnames. Use `["*"]` for all; omit to deny all. |
 | `sys` | list | **Deno only.** System-info APIs (`hostname`, `osRelease`, …). |
 | `dicode` | object | dicode runtime API access (`tasks`, `mcp`, `list_tasks`, `get_runs`, `secrets_write`). |
+
+::: warning Write-protected daemon files
+`dicode.lock` and `dicode.yaml` are unconditionally write-protected for all tasks, regardless of declared `permissions.fs` grants. A task with `permissions.fs: [{path: /home/user/.dicode, permission: w}]` covering the config directory will still receive `NotCapable` (Deno) or `PermissionError` (Python) when it tries to write or remove either file. This protection cannot be overridden via taskset `overrides:` — it is enforced by the runtime at the flag / audit-hook level to guard the approval-gate state.
+:::
 
 ### `env_read_exposed` — grant unrestricted env read (Deno / npm escape hatch)
 


### PR DESCRIPTION
## Summary

- Documents that `dicode.lock` and `dicode.yaml` are unconditionally write-protected from all task code, regardless of declared `permissions.fs` grants
- Covers both Deno (`--deny-write` flag) and Python (`fs_deny` audit hook) runtimes
- Explains that this protection cannot be overridden via taskset `overrides:` and why (approval-gate state integrity)

## Changes

- `docs-src/concepts/tasks.md` — added `:::warning Write-protected daemon files` callout immediately after the Permissions field reference table; updated `fs` row description to point to the new note
- `docs-src/concepts/security.md` — added new **Task write protections** section after the Audit Log section

## References

Closes #95
Implements documentation for dicode-ayo/dicode-core#431

## Test plan

- [x] `npm ci && npm run build` passes (no broken links or Vite/VitePress errors)
- [ ] Review warning callout renders correctly in VitePress
- [ ] New security section is reachable from the tasks page cross-link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qrekSu1zC7TcGAXFrYYD1

---
_Generated by [Claude Code](https://claude.ai/code/session_015qrekSu1zC7TcGAXFrYYD1)_