### PR TITLE
docs: document daemon crash backoff and SIGHUP graceful shutdown

### DIFF
--- a/docs-src/concepts/triggers.md
+++ b/docs-src/concepts/triggers.md
@@ -297,7 +297,7 @@ When a daemon exits and is eligible for restart, dicode waits before re-launchin
 | 5th | 16 seconds |
 | 6th+ | 30 seconds (cap) |
 
-The backoff resets if the daemon ran stably for **at least 10 seconds** before the crash — a healthy long-lived daemon that eventually exits is not penalised. A daemon that crashes immediately on every boot will reach the 30-second inter-restart gap by the sixth attempt. This is intentional: the cap keeps the process alive and retrying without saturating the CPU.
+The backoff resets if the daemon ran stably for **at least 10 seconds** before the crash — a healthy long-lived daemon that eventually exits is not penalised. A daemon that crashes immediately on every boot hits the 30-second cap (applied to what the doubling would otherwise make 32 seconds) by the sixth restart. This is intentional: the cap keeps the process alive and retrying without saturating the CPU.
 
 Backoff state is per-daemon and in-memory — it resets when `dicode daemon` itself restarts.
 
@@ -307,9 +307,9 @@ Backoff state is per-daemon and in-memory — it resets when `dicode daemon` its
 
 ::: tip Deployment notes
 - **systemd** — the default `KillSignal` is `SIGTERM`, which works. No extra configuration needed.
-- **supervisord** — `stopsignal=TERM` (the default) works. `SIGHUP` is also accepted if you use it to reload your supervisor tree.
+- **supervisord** — `stopsignal=TERM` (the default) works. Note that `SIGHUP` also triggers a full graceful shutdown — if your supervisord setup sends `SIGHUP` to managed processes during a reload, dicode will shut down, not stay running.
 - **Docker** — set `STOPSIGNAL SIGTERM` in your `Dockerfile` (already the default).
-- **Kubernetes** — the default `preStop` grace period sends `SIGTERM`; dicode will drain and exit cleanly within the `terminationGracePeriodSeconds` window.
+- **Kubernetes** — Kubernetes sends `SIGTERM` directly to PID 1 when a pod terminates. dicode will drain in-flight runs and exit cleanly within the `terminationGracePeriodSeconds` window.
 :::
 
 ### MCP server daemons

--- a/docs-src/concepts/triggers.md
+++ b/docs-src/concepts/triggers.md
@@ -246,6 +246,24 @@ trigger:
     on: failure
 ```
 
+### Chain constraints
+
+#### Cycle detection
+
+Success chains are validated for cycles at registration time. If adding a task would create a cycle (for example, task A chains from B, and B chains from A), the completing task is **rejected** — it is not armed and will not fire. A warning is written to the daemon log identifying the cycle.
+
+::: warning
+A cyclic chain does not crash dicode; the task is simply skipped during registration. To fix it, correct the cycle in `task.yaml` and push — the reconciler re-registers the task on the next sync (within ~30 seconds).
+:::
+
+#### Depth cap
+
+Success chains have a maximum depth of **10**. When a chain reaches depth 10, further chaining is terminated and a warning is written to the daemon log. Design pipelines that exceed this limit using explicit cron or manual triggers at intermediate stages.
+
+::: tip
+Failure chains have had a depth cap since before v0.4.0. The depth cap for success chains was introduced in dicode-core PR [#438](https://github.com/dicode-ayo/dicode-core/pull/438).
+:::
+
 ---
 
 ## Daemon
@@ -265,6 +283,34 @@ trigger:
 | `always` | Restart the task whenever it exits (default) |
 | `on-failure` | Restart only if the task exits with a non-zero status |
 | `never` | Do not restart; the task runs once at startup |
+
+### Crash backoff
+
+When a daemon exits and is eligible for restart, dicode waits before re-launching it. The wait follows an exponential schedule to prevent CPU thrash from daemons that crash immediately on every boot:
+
+| Restart attempt | Wait before re-launch |
+|---|---|
+| 1st | 1 second |
+| 2nd | 2 seconds |
+| 3rd | 4 seconds |
+| 4th | 8 seconds |
+| 5th | 16 seconds |
+| 6th+ | 30 seconds (cap) |
+
+The backoff resets if the daemon ran stably for **at least 10 seconds** before the crash — a healthy long-lived daemon that eventually exits is not penalised. A daemon that crashes immediately on every boot will reach the 30-second inter-restart gap by the sixth attempt. This is intentional: the cap keeps the process alive and retrying without saturating the CPU.
+
+Backoff state is per-daemon and in-memory — it resets when `dicode daemon` itself restarts.
+
+### Shutdown signals
+
+`dicode daemon` responds to **`SIGTERM`**, **`SIGINT`**, and **`SIGHUP`** with a graceful shutdown: in-flight runs are cancelled, logs are flushed, and the database is closed cleanly before the process exits.
+
+::: tip Deployment notes
+- **systemd** — the default `KillSignal` is `SIGTERM`, which works. No extra configuration needed.
+- **supervisord** — `stopsignal=TERM` (the default) works. `SIGHUP` is also accepted if you use it to reload your supervisor tree.
+- **Docker** — set `STOPSIGNAL SIGTERM` in your `Dockerfile` (already the default).
+- **Kubernetes** — the default `preStop` grace period sends `SIGTERM`; dicode will drain and exit cleanly within the `terminationGracePeriodSeconds` window.
+:::
 
 ### MCP server daemons
 

--- a/docs-src/concepts/triggers.md
+++ b/docs-src/concepts/triggers.md
@@ -250,18 +250,18 @@ trigger:
 
 #### Cycle detection
 
-Success chains are validated for cycles at registration time. If adding a task would create a cycle (for example, task A chains from B, and B chains from A), the completing task is **rejected** — it is not armed and will not fire. A warning is written to the daemon log identifying the cycle.
+Success chains are validated for cycles at registration time. If registering a task would create a cycle (for example, task A chains from B, and B chains from A), the **new task is rejected** — its trigger is not armed and it will not fire. A warning is written to the daemon log identifying the cycle.
 
 ::: warning
-A cyclic chain does not crash dicode; the task is simply skipped during registration. To fix it, correct the cycle in `task.yaml` and push — the reconciler re-registers the task on the next sync (within ~30 seconds).
+To fix a cycle rejection: correct the chain in the offending `task.yaml` and push — the reconciler re-registers the task on the next sync (within ~30 seconds). The daemon does not need to restart.
 :::
 
 #### Depth cap
 
-Success chains have a maximum depth of **10**. When a chain reaches depth 10, further chaining is terminated and a warning is written to the daemon log. Design pipelines that exceed this limit using explicit cron or manual triggers at intermediate stages.
+Success chains have a maximum depth of **10 hops** past the root trigger. The cap is enforced at runtime: once a chain is 10 hops deep, the engine stops firing further hops and writes a warning to the daemon log. Hops 1–10 execute normally; hop 11 and beyond are suppressed. Design pipelines that require more stages using explicit cron or manual triggers at intermediate steps.
 
 ::: tip
-Failure chains have had a depth cap since before v0.4.0. The depth cap for success chains was introduced in dicode-core PR [#438](https://github.com/dicode-ayo/dicode-core/pull/438).
+Failure chains have a configurable depth cap with a default of **2** (`on_failure_chain.max_depth` in `task.yaml`). Both caps prevent infinite loops caused by misconfigured chains.
 :::
 
 ---


### PR DESCRIPTION
## Summary

Closes #99

Documents two operator-visible daemon lifecycle changes introduced by dicode-core PR [#438](https://github.com/dicode-ayo/dicode-core/pull/438) (which closes dicode-core issue #387):

- **Crash backoff**: Restart delay changed from fixed 2s to exponential backoff (1s → 2s → 4s → 8s → 16s → 30s cap). Backoff resets after ≥10s stable run. Prevents CPU thrash for daemons that crash on startup.
- **SIGHUP graceful shutdown**: `dicode daemon` now handles `SIGHUP` (in addition to `SIGTERM`/`SIGINT`) as a graceful shutdown signal — cancels in-flight runs, flushes logs, closes DB.

## Files touched

- `docs-src/concepts/triggers.md` — added `### Crash backoff` and `### Shutdown signals` subsections inside the `## Daemon` section, after the Restart policies table.

## Test plan

- [x] `npm run build` passes clean
- [ ] Review prose for accuracy against dicode-core#438 implementation
- [ ] Verify backoff table values match Go implementation (1s initial, doubles, 30s cap, resets at ≥10s stable)

Refs: dicode-ayo/dicode-core#438, dicode-core#387

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf17hfb5Gk5CmXvZYLrnWb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented chained trigger constraints including cycle detection to prevent cyclic task chains and maximum depth enforcement (10 hops for success chains, configurable for failure chains)
  * Added daemon restart crash backoff behavior documentation featuring exponential wait schedules between attempts, stability thresholds, and memory-based backoff state management
  * Expanded graceful shutdown signal handling documentation with specifics on signal types, in-flight run cancellation, log flushing, and database closure across systemd, supervisord, Docker, and Kubernetes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->