### PR TITLE
docs: document success-chain cycle detection and depth cap

### DIFF
--- a/docs-src/concepts/triggers.md
+++ b/docs-src/concepts/triggers.md
@@ -246,6 +246,24 @@ trigger:
     on: failure
 ```
 
+### Chain constraints
+
+#### Cycle detection
+
+Success chains are validated for cycles at registration time. If adding a task would create a cycle (for example, task A chains from B, and B chains from A), the completing task is **rejected** — it is not armed and will not fire. A warning is written to the daemon log identifying the cycle.
+
+::: warning
+A cyclic chain does not crash dicode; the task is simply skipped during registration. To fix it, correct the cycle in `task.yaml` and push — the reconciler re-registers the task on the next sync (within ~30 seconds).
+:::
+
+#### Depth cap
+
+Success chains have a maximum depth of **10**. When a chain reaches depth 10, further chaining is terminated and a warning is written to the daemon log. Design pipelines that exceed this limit using explicit cron or manual triggers at intermediate stages.
+
+::: tip
+Failure chains have had a depth cap since before v0.4.0. The depth cap for success chains was introduced in dicode-core PR [#438](https://github.com/dicode-ayo/dicode-core/pull/438).
+:::
+
 ---
 
 ## Daemon

--- a/docs-src/concepts/triggers.md
+++ b/docs-src/concepts/triggers.md
@@ -250,18 +250,18 @@ trigger:
 
 #### Cycle detection
 
-Success chains are validated for cycles at registration time. If adding a task would create a cycle (for example, task A chains from B, and B chains from A), the completing task is **rejected** — it is not armed and will not fire. A warning is written to the daemon log identifying the cycle.
+Success chains are validated for cycles at registration time. If registering a task would create a cycle (for example, task A chains from B, and B chains from A), the **new task is rejected** — its trigger is not armed and it will not fire. A warning is written to the daemon log identifying the cycle.
 
 ::: warning
-A cyclic chain does not crash dicode; the task is simply skipped during registration. To fix it, correct the cycle in `task.yaml` and push — the reconciler re-registers the task on the next sync (within ~30 seconds).
+To fix a cycle rejection: correct the chain in the offending `task.yaml` and push — the reconciler re-registers the task on the next sync (within ~30 seconds). The daemon does not need to restart.
 :::
 
 #### Depth cap
 
-Success chains have a maximum depth of **10**. When a chain reaches depth 10, further chaining is terminated and a warning is written to the daemon log. Design pipelines that exceed this limit using explicit cron or manual triggers at intermediate stages.
+Success chains have a maximum depth of **10 hops** past the root trigger. The cap is enforced at runtime: once a chain is 10 hops deep, the engine stops firing further hops and writes a warning to the daemon log. Hops 1–10 execute normally; hop 11 and beyond are suppressed. Design pipelines that require more stages using explicit cron or manual triggers at intermediate steps.
 
 ::: tip
-Failure chains have had a depth cap since before v0.4.0. The depth cap for success chains was introduced in dicode-core PR [#438](https://github.com/dicode-ayo/dicode-core/pull/438).
+Failure chains have a configurable depth cap with a default of **2** (`on_failure_chain.max_depth` in `task.yaml`). Both caps prevent infinite loops caused by misconfigured chains.
 :::
 
 ---


### PR DESCRIPTION
## Summary

Closes #98

Documents two new chain constraints introduced by dicode-core PR [#438](https://github.com/dicode-ayo/dicode-core/pull/438) (which closes dicode-core issue [#387](https://github.com/dicode-ayo/dicode-core/issues/387)):

- **Cycle detection**: Success chains are validated for cycles at registration time. If a cycle is detected, the completing task is rejected (not armed) and a warning is written to the daemon log. Previously, mutual chains looped forever.
- **Depth cap of 10**: Success chains are now capped at depth 10 in `FireChain`. Failure chains already had a cap; success chains were previously uncapped.

## Files touched

- `docs-src/concepts/triggers.md` — added `### Chain constraints` subsection after the "Chaining multiple tasks" example, with two sub-sections: Cycle detection (with a `::: warning` callout) and Depth cap (with a `::: tip` noting the history of the failure-chain cap).

## Test plan

- [x] `npm run build` passes clean
- [ ] Review prose for accuracy against dicode-core PR #438
- [ ] Verify `::: warning` and `::: tip` callouts render correctly in VitePress

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf17hfb5Gk5CmXvZYLrnWb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf17hfb5Gk5CmXvZYLrnWb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation on chain constraints covering cycle detection (automatic rejection of circular task chains) and depth limitations (maximum 10 hops for success chains, configurable maximum for failure chains) to prevent infinite loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->