### PR TITLE
docs: concurrent dev-mode clone sessions (sdk.md + auto-fix.md)

### DIFF
--- a/docs-src/concepts/auto-fix.md
+++ b/docs-src/concepts/auto-fix.md
@@ -81,6 +81,10 @@ The trigger engine enforces hard caps before every `on_failure_chain` fire — t
 | Branch prefix | `fix/` | `on_failure_chain.params.branch_prefix` |
 | `--force` push | always refused | not configurable |
 
+::: tip Concurrent sessions across the same source
+Since dicode-core #444, multiple auto-fix sessions targeting different tasks from the **same source** run concurrently, up to the global cap. Previously, the dev-mode layer serialised them (returning `ErrDevModeBusy` for any second session), making the global cap unreachable for same-source failures. If you set the global cap lower than 3 as a workaround, you may now raise it.
+:::
+
 `max_concurrent_global` and `storm` are **operator policy** — only honored at the defaults level. Per-task blocks that set them get a config-load WARN and the fields are zeroed.
 
 State (cooldown timestamps, in-flight counters, storm windows) lives in memory on the daemon. A daemon restart resets it — by design for v1; persistence is a future enhancement.

--- a/docs-src/concepts/auto-fix.md
+++ b/docs-src/concepts/auto-fix.md
@@ -82,7 +82,7 @@ The trigger engine enforces hard caps before every `on_failure_chain` fire — t
 | `--force` push | always refused | not configurable |
 
 ::: tip Concurrent sessions across the same source
-Since dicode-core #444, multiple auto-fix sessions targeting different tasks from the **same source** run concurrently, up to the global cap. Previously, the dev-mode layer serialised them (returning `ErrDevModeBusy` for any second session), making the global cap unreachable for same-source failures. If you set the global cap lower than 3 as a workaround, you may now raise it.
+Since dicode-core #444, multiple dev-mode clone sessions on the **same source** run concurrently as long as each uses a distinct `run_id` — whether they target the same task or different ones. Previously, a second `SetDevMode` call on the same source was rejected regardless of `run_id`, making source-level serialization the effective limit (below the engine's global cap). If you set the global cap lower than 3 as a workaround, you may now raise it.
 :::
 
 `max_concurrent_global` and `storm` are **operator policy** — only honored at the defaults level. Per-task blocks that set them get a config-load WARN and the fields are zeroed.

--- a/docs-src/concepts/sdk.md
+++ b/docs-src/concepts/sdk.md
@@ -360,6 +360,8 @@ Toggle dev mode on a configured taskset source. Two modes:
 - **local-path:** point the source at a local checkout for live edits
 - **clone-mode:** clone the remote into a per-fix directory checked out on a feature branch (used by auto-fix; cloned at `${data}/dev-clones/<source>/<run_id>/`)
 
+  Clone-mode supports **multiple concurrent sessions** — each keyed by a distinct `run_id`. Passing the same `run_id` a second time returns `ErrDevModeBusy`. The registry surfaces the **most-recently-activated session as primary** (the one the reconciler reads). A targeted disable removes only the named session; primary is then promoted to the next most-recent.
+
 ::: code-group
 
 ```ts [Deno]
@@ -377,7 +379,10 @@ await dicode.sources.set_dev_mode("infra", {
   run_id: "abc123",
 });
 
-// Disable
+// Disable targeted session (leaves other sessions running)
+await dicode.sources.set_dev_mode("infra", { enabled: false, run_id: "abc123" });
+
+// Disable all sessions (backward-compatible — omit run_id)
 await dicode.sources.set_dev_mode("infra", { enabled: false });
 ```
 
@@ -396,6 +401,10 @@ dicode.sources.set_dev_mode(
     run_id="abc123",
 )
 
+# Disable targeted session
+dicode.sources.set_dev_mode("infra", enabled=False, run_id="abc123")
+
+# Disable all sessions
 dicode.sources.set_dev_mode("infra", enabled=False)
 ```
 

--- a/docs-src/concepts/sdk.md
+++ b/docs-src/concepts/sdk.md
@@ -360,7 +360,7 @@ Toggle dev mode on a configured taskset source. Two modes:
 - **local-path:** point the source at a local checkout for live edits
 - **clone-mode:** clone the remote into a per-fix directory checked out on a feature branch (used by auto-fix; cloned at `${data}/dev-clones/<source>/<run_id>/`)
 
-  Clone-mode supports **multiple concurrent sessions** — each keyed by a distinct `run_id`. Passing the same `run_id` a second time returns `ErrDevModeBusy`. The registry surfaces the **most-recently-activated session as primary** (the one the reconciler reads). A targeted disable removes only the named session; primary is then promoted to the next most-recent.
+  Clone-mode supports **multiple concurrent sessions** — each keyed by a distinct `run_id`. Passing the same `run_id` a second time returns an error. The registry surfaces the **most-recently-activated session as primary** (the one the reconciler reads; only the primary session's changes are reflected while other sessions remain isolated). A targeted disable removes only the named session — if the removed session was the primary, the next most-recently-created session is promoted. Use a UUID or the triggering run's ID as `run_id` to avoid collisions with other sessions.
 
 ::: code-group
 


### PR DESCRIPTION
## Summary

- Documents that clone-mode `set_dev_mode` now supports multiple concurrent sessions keyed by distinct `run_id` (dicode-core #444)
- Updates the Deno and Python code examples to show targeted disable (`{ enabled: false, run_id: "abc123" }`) alongside the existing all-sessions disable
- Adds a `:::tip` callout in `auto-fix.md`'s Engine guardrails section explaining that the source-level serialization (`ErrDevModeBusy` for any second session) is removed and operators who lowered the global cap as a workaround may now raise it

## Test plan

- [x] `npm run build` passes with zero errors
- [x] Both files changed: `docs-src/concepts/sdk.md` and `docs-src/concepts/auto-fix.md`
- [x] Deno and Python disable examples both updated
- [x] Tip block renders as VitePress `::: tip` container

Closes #103
Ref: dicode-ayo/dicode-core#444

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131N46hjbFiRgEFpR9nxLJw

---
_Generated by [Claude Code](https://claude.ai/code/session_0131N46hjbFiRgEFpR9nxLJw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified clone-mode behavior for concurrent development sessions on the same source when each uses a different run ID.
  * Added guidance on how session precedence works when multiple sessions are active, including what happens when a targeted session is disabled.
  * Updated examples to show both disabling a specific session and disabling all sessions for backward compatibility.
  * Expanded engine guidance to note that previous source-level serialization no longer always applies and that related operational advice may need adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->