### PR TITLE
docs: update permissions.net to cover Docker/Podman network isolation

### DIFF
--- a/docs-src/concepts/runtimes.md
+++ b/docs-src/concepts/runtimes.md
@@ -290,6 +290,16 @@ docker:
   pull_policy: missing
 ```
 
+::: warning Container security floor
+By default, dicode rejects Docker and Podman task configurations that use host networking, dangerous Linux capabilities, insecure `security_opt` values, or bind mounts to sensitive system paths. Tasks with such configuration will fail at start time with a descriptive error.
+
+To opt in to a specific exception, add a `container_security:` block to `dicode.yaml` — see [Container Security](/getting-started/configuration#container-security). Named and anonymous volumes (not host bind-mounts) are always allowed.
+:::
+
+::: info Network isolation
+When `permissions.net` is empty and the task publishes no `docker.ports`, the container starts with `network_mode: none` — no outbound network access. Declare `permissions.net: ["*"]` for unrestricted network, or list specific hosts (allowed but not yet per-host enforced; a warning is logged). An explicit `docker.network_mode` always takes precedence.
+:::
+
 ---
 
 ## Podman
@@ -300,6 +310,7 @@ A rootless, daemonless alternative to Docker. Uses the same `docker:` config blo
 - **Same config**: Uses the identical `docker:` block in task.yaml -- just change `runtime: podman`.
 - **Drop-in replacement**: If you can run it with Docker, you can run it with Podman.
 - **Security floor**: Certain host-facing options (`network_mode: host`, dangerous `cap_add`, insecure `security_opt`, sensitive bind mounts) are rejected by default. See [Container Security](/getting-started/configuration#container-security) for details and opt-in configuration.
+- **Network isolation**: Same zero-default as Docker — containers with empty `permissions.net` and no published ports start with `network_mode: none`. See the Docker section above.
 
 ```yaml
 apiVersion: dicode/v1

--- a/docs-src/concepts/tasks.md
+++ b/docs-src/concepts/tasks.md
@@ -317,7 +317,7 @@ The `permissions` block declares what the task is allowed to access. Nothing is 
 See [Secrets](./secrets.md) for details on `permissions.env` and secret injection.
 
 ::: tip
-For Deno tasks, permissions map directly to Deno's `--allow-*` flags. Python and Docker tasks use env injection only (`permissions.env`).
+For Deno tasks, `permissions.net`, `permissions.fs`, `permissions.run`, and `permissions.sys` map directly to Deno's `--allow-*` flags. Python tasks enforce only `permissions.env`. Docker and Podman tasks enforce `permissions.env` (env injection) and `permissions.net` (network isolation — see the `net` row below); the fs/run/sys fields are not yet enforced for container runtimes.
 :::
 
 ### Permissions field reference
@@ -328,7 +328,7 @@ For Deno tasks, permissions map directly to Deno's `--allow-*` flags. Python and
 | `env_read_exposed` | bool | **Deno only.** Grant bare `--allow-env` (read any env var). Default `false`. See below. |
 | `fs` | list | **Deno (read + write); Python (write mode only).** Filesystem paths and access modes (`r`, `w`, `rw`). See write-protection note below. |
 | `run` | list | Executables the script may spawn (`Deno.Command` / Python `subprocess`). Use `["*"]` for all; omit to deny all. |
-| `net` | list | Outbound network hostnames. Use `["*"]` for all; omit to deny all. |
+| `net` | list | Outbound network hostnames. Use `["*"]` for unrestricted; omit or use `[]` to deny all. **Docker/Podman**: empty list → container starts with `network_mode: none`; specific hosts are informational only today (per-host filtering not yet implemented; a warning is logged). |
 | `sys` | list | **Deno only.** System-info APIs (`hostname`, `osRelease`, …). |
 | `dicode` | object | dicode runtime API access (`tasks`, `mcp`, `list_tasks`, `get_runs`, `secrets_write`). |
 


### PR DESCRIPTION
Companion to dicode-ayo/dicode-core#449, which adds zero-default network isolation for Docker/Podman tasks.

## Summary

- **`docs-src/concepts/tasks.md`**: fix stale tip that said "Python and Docker tasks use env injection only" — `permissions.net` now also gates network for Docker/Podman. Update the `permissions.net` table row to describe the `network_mode: none` zero-default and the ports exception.
- **`docs-src/concepts/runtimes.md`**: add a Network isolation info block after the Docker security floor warning; add a Network isolation bullet to the Podman feature list.

## Test plan

- [ ] Preview docs build renders the new info block without formatting errors
- [ ] Cross-links to the Container Security configuration page are intact

---
_Generated by [Claude Code](https://claude.ai/code/session_013u5ffiDzyN2xNwSTicPiEK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how runtime permissions are enforced across Deno, Python, Docker, and Podman tasks.
  * Added clearer guidance on network isolation defaults, including when network access is disabled and how to enable it.
  * Expanded runtime docs with container security and isolation behavior so the default behavior is easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->