### PR TITLE
docs: document Python dependency pinning (task.py.lock, dicode python relock)

### DIFF
--- a/docs-src/concepts/runtimes.md
+++ b/docs-src/concepts/runtimes.md
@@ -92,7 +92,7 @@ tasks/
 
 **Missing lockfile entry**: If an import is not present in the lockfile (for example, after adding a new `npm:` dependency without updating the lockfile), Deno fails at task startup with a lockfile integrity error. Fix it by running `deno install` (or `deno cache task.ts` for older Deno versions) inside the task directory to regenerate the lockfile, then commit the updated `deno.lock`.
 
-**Unified relock**: `dicode relock [--check] [dir]` runs this Deno pass together with the Python lock pass (documented below) in one shot, skipping whichever task kind isn't present under the tree -- one command, and one CI step, that covers both `deno.lock` and every `task.py.lock` sidecar.
+**Unified relock**: See "Unified relock" in the Python section below for how `dicode relock` combines this pass with the Python one.
 
 ---
 
@@ -179,7 +179,7 @@ When a task's dependencies change, regenerate the sidecar with `dicode python re
 
 **`--check` mode**: `dicode python relock --check` verifies without writing. It fails fast -- before uv is even provisioned -- on any missing lock sidecar or orphaned sidecar, then runs `uv lock --script --check` per script and exits non-zero on drift. Run it in CI to catch stale locks before they reach the runtime.
 
-**Unified relock**: `dicode relock [--check] [dir]` runs this Python pass together with the Deno pass above in one shot, skipping whichever task kind isn't present under the tree -- one command, and one CI step, that covers both `deno.lock` and every `task.py.lock` sidecar.
+**Unified relock**: `dicode relock [--check] [dir]` runs this Python pass together with the Deno pass above in one shot, skipping whichever task kind isn't present under the tree -- one command, and one CI step, that covers both `deno.lock` and every `task.py.lock` sidecar. If the tree under `dir` has neither `task.ts` nor `task.py` files at all, `dicode relock` errors instead of silently doing nothing.
 
 ::: warning Pin `requires-python` for a reproducible lock
 Without a `requires-python` constraint in the PEP 723 block, uv resolves against whatever Python version is the environment default -- which can differ between a dev machine and CI -- so the lock it generates won't reproduce elsewhere. `dicode python relock` prints a warning when a lockable script omits it:

--- a/docs-src/concepts/runtimes.md
+++ b/docs-src/concepts/runtimes.md
@@ -92,6 +92,8 @@ tasks/
 
 **Missing lockfile entry**: If an import is not present in the lockfile (for example, after adding a new `npm:` dependency without updating the lockfile), Deno fails at task startup with a lockfile integrity error. Fix it by running `deno install` (or `deno cache task.ts` for older Deno versions) inside the task directory to regenerate the lockfile, then commit the updated `deno.lock`.
 
+**Unified relock**: `dicode relock [--check] [dir]` runs this Deno pass together with the Python lock pass (documented below) in one shot, skipping whichever task kind isn't present under the tree -- one command, and one CI step, that covers both `deno.lock` and every `task.py.lock` sidecar.
+
 ---
 
 ## Python
@@ -159,6 +161,36 @@ from bs4 import BeautifulSoup
 ```
 
 uv resolves and installs these dependencies automatically before running the script.
+
+### Dependency pinning
+
+If a `task.py.lock` sidecar exists next to `task.py` (written by `uv lock --script`), dicode stages it alongside the run and invokes `uv run --locked`. This pins every dependency to the exact versions and hashes recorded in the sidecar -- a stale lock fails the run loudly instead of silently re-resolving. Tasks without a sidecar (including tasks with no PEP 723 block at all) run exactly as before, unlocked -- the same degrade behavior as the Deno runtime when no `deno.lock` is present.
+
+Unlike Deno's single shared `deno.lock`, uv locks scripts individually -- each `task.py` gets its own sidecar next to it:
+
+```
+my-task/
+  task.yaml
+  task.py
+  task.py.lock       # committed sidecar, detected automatically
+```
+
+When a task's dependencies change, regenerate the sidecar with `dicode python relock [dir]` (dir defaults to `tasks`). It provisions the pinned uv version dicode itself runs tasks with and runs `uv lock --script` for every `task.py` under the tree that carries a PEP 723 block, so the lock is deterministic regardless of any system uv. A `task.py.lock` left behind by a script that no longer has a PEP 723 block is orphaned -- it's deleted automatically.
+
+**`--check` mode**: `dicode python relock --check` verifies without writing. It fails fast -- before uv is even provisioned -- on any missing lock sidecar or orphaned sidecar, then runs `uv lock --script --check` per script and exits non-zero on drift. Run it in CI to catch stale locks before they reach the runtime.
+
+**Unified relock**: `dicode relock [--check] [dir]` runs this Python pass together with the Deno pass above in one shot, skipping whichever task kind isn't present under the tree -- one command, and one CI step, that covers both `deno.lock` and every `task.py.lock` sidecar.
+
+::: warning Pin `requires-python` for a reproducible lock
+Without a `requires-python` constraint in the PEP 723 block, uv resolves against whatever Python version is the environment default -- which can differ between a dev machine and CI -- so the lock it generates won't reproduce elsewhere. `dicode python relock` prints a warning when a lockable script omits it:
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["httpx>=0.27"]
+# ///
+```
+:::
 
 ### Logging
 


### PR DESCRIPTION
Closes #113

## What

dicode-core [PR #466](https://github.com/dicode-ayo/dicode-core/pull/466) (merged, closes dicode-core [#465](https://github.com/dicode-ayo/dicode-core/issues/465)) brought Deno-style dependency pinning/reproducibility to Python tasks. The Python side of `docs-src/concepts/runtimes.md` had no equivalent to the Deno runtime's existing "Dependency pinning" subsection, and neither runtime section mentioned the new unified `dicode relock` command.

This PR adds that documentation:

- New "Dependency pinning" subsection under the Python runtime section (mirroring the Deno one in structure), covering:
  - the `task.py.lock` sidecar and how `uv run --locked` enforces it
  - the unlocked degrade path when no sidecar exists (same as Deno with no `deno.lock`)
  - `dicode python relock [--check] [dir]` usage, including orphaned-sidecar cleanup
  - the `requires-python` reproducibility warning
- Cross-references to the new unified `dicode relock [--check] [dir]` frontend added to both the Deno and Python dependency-pinning subsections — a full explanation lives in the Python section, with a short pointer from the Deno section, matching this file's existing Docker/Podman cross-reference convention.

No unrelated content was restructured or rewritten.

## Test plan

- [x] `npm ci` — clean install
- [x] `npm run build` — `vite build site && vitepress build docs-src` passes clean (no broken links, no Vite errors)
- [x] `/security-review` — no findings (documentation-only diff, no executable code/injection surface)
- [x] `/code-review --comment` — no findings after a duplication fix (collapsed two near-verbatim "Unified relock" explanations into one, per review feedback) and adding a caveat about `dicode relock`'s all-absent error case

## Touched files

- `docs-src/concepts/runtimes.md` — added the Python "Dependency pinning" subsection and cross-referenced the unified `dicode relock` command from both the Deno and Python sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added cross-referenced guidance for unified relocking across Deno and Python runtimes.
  * Expanded dependency pinning guidance to explain Python lockfile sidecar behavior, including detection, staging, enforcement, regeneration, and drift checks.
  * Documented the combined relock command and its behavior when no runtime file is present.
  * Added a warning to pin Python version requirements for reproducible locking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->